### PR TITLE
Add the sign in or request access flow

### DIFF
--- a/app/views/check-email.html
+++ b/app/views/check-email.html
@@ -1,0 +1,26 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Check your email" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({href: "/sign-in"}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">{{ pageName }}</h1>
+
+    <p class="govuk-body">You should have received an email sent to {{ data["email"] }} with a link to sign in.</p>
+
+    <p class="govuk-body">If it does not arrive within 5 minutes, check your junk folder or <a href="/sign-in" class="govuk-link">try again</a>.</p>
+
+    <p class="govuk-body">If you still need help, contact us:
+      <a class="govuk-link govuk-link--no-visited-state" href="mailto:continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a>
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/check-school-email.html
+++ b/app/views/check-school-email.html
@@ -1,0 +1,22 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Check your school email" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">{{ pageName }}</h1>
+
+    <p class="govuk-body">We’ve sent a link to the school’s email address at p************t@{{ data.schoolName | lower | slugify }}.sch.uk</p>
+
+    <p class="govuk-body">If it does not arrive within 5 minutes, check your junk folder or <a href="/request-access" class="govuk-link">try again</a>.</p>
+
+    <p class="govuk-body">If you still need help, contact us:
+      <a class="govuk-link govuk-link--no-visited-state" href="mailto:continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a>
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/confirm-school.html
+++ b/app/views/confirm-school.html
@@ -1,0 +1,62 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Confirm this is your school" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <h1 class="govuk-heading-l">{{ pageName }}</h1>
+
+      {{ govukSummaryList({
+        classes: 'govuk-!-margin-bottom-9',
+        rows: [
+          {
+            key: {
+              text: "Name"
+            },
+            value: {
+              text: data.schoolName
+            },
+            actions: {
+              items: [
+                {
+                  href: "/local-authority",
+                  text: "Change",
+                  visuallyHiddenText: "school name"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "URN"
+            },
+            value: {
+              text: "185634"
+            }
+          },
+          {
+            key: {
+              text: "Address"
+            },
+            value: {
+              html: "Dover Street<br>Ryde<br>Isle of Wight<br>PO33 2BN"
+            }
+          }
+        ]
+      }) }}
+
+      <form action="/check-school-email" method="post" novalidate>
+
+      <p>We will send an email to p************t@{{ data.schoolName | lower | slugify }}.sch.uk with a link to access the service.</p>
+
+      {{ govukButton({
+        text: "Confirm and send"
+      }) }}
+
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -7,7 +7,34 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <p class="govuk-body"><a href="/participants?show=training" class="govuk-link">Manage mentors and ECTs</a></p>
+    <h1 class="govuk-heading-xl">{{ serviceName }}</h1>
+
+    <p class="govuk-body">Use this service to set up ECF-based training for your early career teachers (ECTs) or tell us about a change at your school.</p>
+
+    <h2 class="govuk-heading-m">Set up and manage your training</h2>
+
+    <p class="govuk-body">Tell us:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>how you want to run your training</li>
+        <li>which accredited materials or training provider you’ll use</li>
+        <li>which ECTs and mentors will take part</li>
+    </ul>
+
+    <p class="govuk-body">Your school must complete these steps before your ECTs can start their statutory induction programme.</p>
+
+    <h2 class="govuk-heading-m">Tell us about changes at your school</h2>
+
+    <p class="govuk-body">Tell us about any changes, for example, nominating a new induction tutor.</p>
+
+
+    <div class="govuk-button-group govuk-body govuk-!-margin-top-7">
+      {{ govukButton({text: "Sign in", href: "/sign-in" }) }}
+
+        <span class="govuk-!-margin-right-2">or</span>
+
+        <a class="govuk-link govuk-link--no-visited-state" href="/request-access">request access to the service</a>
+    </div>
 
   </div>
 </div>

--- a/app/views/local-authority.html
+++ b/app/views/local-authority.html
@@ -1,0 +1,37 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What’s your school’s local authority?" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({href: "/"}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form action="/school-name" method="post">
+
+      {{ govukInput({
+        name: "localAuthority",
+        value: data.localAuthority,
+        label: {
+          text: pageName,
+          classes: "govuk-label--l",
+          isPageHeading: true
+        },
+        hint: {
+          text: "This is the local authority or council in your area."
+        }
+
+      }) }}
+
+      {{ govukButton({ text: "Continue" }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/request-access.html
+++ b/app/views/request-access.html
@@ -1,0 +1,30 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Send your school a link to use this service" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({href: "/"}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">{{ pageName }}</h1>
+
+    <p class="govuk-body">We need some information to help us find your school in the Get Information about Schools (GIAS) register.</p>
+
+    <p class="govuk-body">We’ll then send a link to the email address held in the register.</p>
+    <p class="govuk-body govuk-!-margin-bottom-7 govuk-inset-text">
+        You can
+        <a class="govuk-link govuk-link govuk-link--no-visited-state" href="https://services.signin.education.gov.uk/">sign in to the DfE</a>
+         to check that your school’s email address is up to date before you start.
+    </p>
+
+    {{ govukButton({ text: "Continue", href: "/local-authority" }) }}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/school-name.html
+++ b/app/views/school-name.html
@@ -1,0 +1,34 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What’s the name of your school?" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({href: "/local-authority"}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form action="/confirm-school" method="post">
+
+      {{ govukInput({
+        name: "schoolName",
+        value: data.schoolName,
+        label: {
+          text: pageName,
+          classes: "govuk-label--l",
+          isPageHeading: true
+        }
+
+      }) }}
+
+      {{ govukButton({ text: "Continue" }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/sign-in.html
+++ b/app/views/sign-in.html
@@ -1,0 +1,39 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Sign in" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({href: "/"}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">{{ pageName }}</h1>
+
+    <form action="/check-email" method="post">
+
+      {{ govukInput({
+        label: {
+          text: "Email address"
+        },
+        id: "email",
+        name: "email",
+        type: "email",
+        autocomplete: "email",
+        spellcheck: false
+      }) }}
+
+      {{ govukButton({ text: "Sign in"}) }}
+
+    </form>
+
+    <p class="govuk-body">Or <a class="govuk-link govuk-link--no-visited-state" href="/request-access">request access to the service</a>
+    </p>
+
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This flow is the same as in production, but with some changes to the content:

* include the email address the email was sent to in the "Check your email" screens
* include the partially-redacted email address before confirming the school within the request access flow
* always direct people to their inbox within the sign in flow, as we’d send them an email even if they're not yet registered