### PR TITLE
Show induction start dates (and allow users to sort by them)

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -98,7 +98,7 @@ module.exports = {
           trn: "6254724",
           dateOfBirth: "1989-11-13",
           emailAddress: "lillian.solis@plymouth-primary.sch.uk",
-          inductionStartDate: "2022-09-03"
+          inductionStartDate: "2021-09-03"
         }
       ]
     },

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -39,7 +39,7 @@ module.exports = {
           trn: "8274762",
           dateOfBirth: "1989-11-13",
           emailAddress: "abney.cartwright@plymouth-primary.sch.uk",
-          inductionStartDate: "2022-09-20"
+          inductionStartDate: "2023-04-20"
         }
       ]
     },
@@ -64,7 +64,7 @@ module.exports = {
           trn: "6274624",
           dateOfBirth: "1989-11-13",
           emailAddress: "naomi.yoder@plymouth-primary.sch.uk",
-          inductionStartDate: "2022-09-20"
+          inductionStartDate: "2022-10-03"
         }
       ]
     },
@@ -98,7 +98,7 @@ module.exports = {
           trn: "6254724",
           dateOfBirth: "1989-11-13",
           emailAddress: "lillian.solis@plymouth-primary.sch.uk",
-          inductionStartDate: "2022-09-20"
+          inductionStartDate: "2022-09-03"
         }
       ]
     },
@@ -115,7 +115,7 @@ module.exports = {
           trn: "94762652",
           dateOfBirth: "1989-11-13",
           emailAddress: "elvis.welch@plymouth-primary.sch.uk",
-          inductionStartDate: "2022-09-20"
+          inductionStartDate: "2023-06-20"
         }
       ]
     }
@@ -142,7 +142,7 @@ module.exports = {
     {
       id: "DCP634",
       name: "Nina Eaton",
-      inductionStartDate: "2022-09-20",
+      inductionStartDate: "2022-09-12",
       completedDate: "2023-03-23",
       trn: "7254724",
       dateOfBirth: "1989-11-13",

--- a/app/routes.js
+++ b/app/routes.js
@@ -9,16 +9,44 @@ const router = govukPrototypeKit.requests.setupRouter()
 
 router.get('/participants', (req, res) => {
 
-  // Check all options if none are checked
-  let show = req.session.data.show
-  if (show === undefined || show === [] || show === ['_unchecked']) {
-    req.session.data.show = [
-      'training', 'completed-induction', 'no-longer-training'
-    ]
-    res.redirect('/participants')
-  }  else {
-    res.render('participants')
+  let ectsBeingTrained = []
+
+  for (mentor of req.session.data.mentors) {
+    for (teacher of mentor.earlyCareerTeachers) {
+
+      teacher.mentor = {
+        name: mentor.name,
+        id: mentor.id
+      }
+      ectsBeingTrained.push(teacher)
+    }
+
+
   }
+
+  ectsBeingTrained.push(req.session.data.teachersWithoutMentors)
+
+  ectsBeingTrained = ectsBeingTrained.flat()
+
+  ectsBeingTrained = ectsBeingTrained.sort(function(teacherA, teacherB) {
+    if (!teacherA.inductionStartDate) {
+      return -1
+    }
+
+    if (!teacherB.inductionStartDate) {
+      return 1
+    }
+
+    if (teacherA.inductionStartDate > teacherB.inductionStartDate) {
+      return -1
+    } else {
+      return 1
+    }
+  })
+
+  res.render('participants', {
+    ectsBeingTrained
+  })
 
 })
 

--- a/app/views/early-career-teacher.html
+++ b/app/views/early-career-teacher.html
@@ -20,13 +20,29 @@
 {% block content %}
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-three-quarters">
 
     <span class="govuk-caption-l">Early career teacher</span>
     <h1 class="govuk-heading-l">{{ teacher.name }}</h1>
 
     {% set tagText = "Training" if teacher.inductionStartDate else "Eligible for training" %}
-    {% set statusText = "Their induction started on <span style=\"white-space: nowrap;\">" + (teacher.inductionStartDate | govukDate) + "</span>" if teacher.inductionStartDate else "We’ve confirmed the participant is eligible for this programme.</p><p class=\"govuk-body\">Alban Teaching School Hub needs to confirm their induction start date." %}
+
+    {% set statusText %}
+      {% if teacher.inductionStartDate %}
+        Induction started on <span style="white-space: nowrap;">{{ teacher.inductionStartDate | govukDate }}</span>
+
+        {% if teacher.inductionStartDate < "2021-09-30" %}
+          <p class="govuk-body">Alban Teaching School Hub will record the induction completed date when {{ teacher.name }} has passed their induction.</p>
+
+          <p class="govuk-body">There may be a delay before this information is updated here.</p>
+        {% endif %}
+      {% else %}
+        We’ve confirmed the participant is eligible for this programme</p>
+
+        <p class="govuk-body">Alban Teaching School Hub needs to confirm their induction start date.
+      {% endif %}
+    {% endset %}
+
 
     {{ govukSummaryList({
       rows: [

--- a/app/views/participants.html
+++ b/app/views/participants.html
@@ -98,7 +98,7 @@
 
               {% set mentor %}
                 {% if teacher.mentor %}
-                  {{ teacher.mentor.name }}
+                  <a href="/mentors/{{ teacher.mentor.id }}" class="govuk-link">{{ teacher.mentor.name }}</a>
                 {% else %}
                   <div class="govuk-summary-list__missing">
                     <div class="govuk-summary-list__missing-heading">No mentor assigned</div>

--- a/app/views/participants.html
+++ b/app/views/participants.html
@@ -44,7 +44,7 @@
         items: [
           {
             value: "training",
-            text: "Currently training (7)"
+            text: "Currently training (9)"
           },
           {
             value: "completed-induction",

--- a/app/views/participants.html
+++ b/app/views/participants.html
@@ -67,79 +67,152 @@
 
     {% if data.show and data.show == "training" %}
 
-      {% if data.teachersWithoutMentors | length > 0 %}
-
-        {{ govukWarningText({ text: "You need to assign a mentor to these ECTs:",
-        classes: "govuk-!-margin-bottom-3" }) }}
-
-        <ul class="govuk-list govuk-!-margin-bottom-6">
-        {% for teacher in data.teachersWithoutMentors %}
-          <li><a href="/teachers-without-mentors/{{ teacher.id }}" class="govuk-link--no-visited-state">{{ teacher.name }}</a></li>
-        {% endfor %}
-        </ul>
-      {% endif %}
-
       <div class="govuk-!-margin-bottom-8">
-        {% for mentor in data.mentors %}
 
-          <div class="govuk-summary-card">
+        <p class="govuk-body">Sort by:
+          {% if data.sort_by == "mentor" or not data.sort_by %}<b class="govuk-!-margin-left-2">Mentor (A-Z)</b>{% else %}<a href="/participants?show=training&sort_by=mentor" class="govuk-link govuk-!-margin-left-2">Mentor (A-Z)</a>{% endif %}
+
+          {% if data.sort_by == "induction-start-date" %}<b class=" govuk-!-margin-left-2">Induction start date</b>{% else %}<a href="/participants?show=training&sort_by=induction-start-date" class="govuk-link govuk-!-margin-left-2">Induction start date</a>{% endif %}
+        </p>
+
+        {% if data.sort_by == "induction-start-date" %}
+
+          {% for teacher in ectsBeingTrained %}
+
+             <div class="govuk-summary-card">
+            <div class="govuk-summary-card__title-wrapper govuk-!-padding-top-2 govuk-!-padding-bottom-2">
+              <h2 class="govuk-summary-card__title"><a href="/{{ "early-career-teachers" if teacher.mentor else "teachers-without-mentors" }}/{{ teacher.id }}" class="govuk-link govuk-!-font-weight-regular govuk-link--no-visited-state">{{ teacher.name }}</a></h2>
+            </div>
             <div class="govuk-summary-card__content">
 
-              <h2 class="govuk-heading-s govuk-!-margin-bottom-0">Mentor</h2>
+              {% set status %}
+              {% if teacher.inductionStartDate %}
+                {{ govukTag({ text: "Training", classes: "govuk-tag--turquoise" }) }}
 
-              {% set mentorStatusHtml %}
-                {{ govukTag({ text: "Mentoring", classes: "govuk-tag--turquoise" }) }}
+                <p class="govuk-body govuk-!-margin-top-2">Induction started {{ teacher.inductionStartDate | govukDate }}</p>
+
+              {% else %}
+                {{ govukTag({ text: "Eligible for training", classes: "govuk-tag--turquoise" }) }}
+              {% endif %}
               {% endset %}
 
-              {{ govukSummaryList({
-                classes: "govuk-summary-list--no-border govuk-!-margin-bottom-4",
+              {% set mentor %}
+                {% if teacher.mentor %}
+                  {{ teacher.mentor.name }}
+                {% else %}
+                  <div class="govuk-summary-list__missing">
+                    <div class="govuk-summary-list__missing-heading">No mentor assigned</div>
+                    <a href="#" class="govuk-link--no-visited-state">Assign a mentor</a>
+                  </div>
+                {% endif %}
+              {% endset %}
+
+               {{ govukSummaryList({
+                classes: "govuk-summary-list--no-border govuk-!-margin-bottom-0",
                 rows: [
                   {
                     key: {
-                      html: "<a href=\"/mentors/" + mentor.id + "\" class=\"govuk-link--no-visited-state\">" + mentor.name + "</a>",
-                      classes: "govuk-!-font-weight-regular"
+                      text: "Status",
+                      classes: "xgovuk-!-font-weight-regular"
                     },
                     value: {
-                      html: mentorStatusHtml
+                      html: status
+                    }
+                  },
+                  {
+                    key: {
+                      text: "Mentor",
+                      classes: "xgovuk-!-font-weight-regular"
+                    },
+                    value: {
+                      html: mentor
                     }
                   }
                 ]
               }) }}
 
-              <h2 class="govuk-heading-s govuk-!-margin-bottom-0">ECTs</h2>
-
-              {% set rows = [] %}
-
-              {% for earlyCareerTeacher in mentor.earlyCareerTeachers %}
-
-                {% set key = {html: "<a href=\"/early-career-teachers/" + earlyCareerTeacher.id + "\" class=\"govuk-link--no-visited-state\">" + earlyCareerTeacher.name + "</a>", classes: "govuk-!-font-weight-regular"} %}
-
-                {% set valueHtml %}
-                  {% if earlyCareerTeacher.inductionStartDate %}
-                    {{ govukTag({ text: "Training", classes: "govuk-tag--turquoise" }) }}
-
-                  {% else %}
-                    {{ govukTag({ text: "Eligible for training", classes: "govuk-tag--turquoise" }) }}
-                  {% endif %}
-                {% endset %}
-
-                {% set value = {html: valueHtml} %}
-                {% set rows = (rows.push({key: key, value: value}), rows) %}
-              {% endfor %}
-
-              {% set mentorStatusHtml %}
-                {{ govukTag({ text: "Mentoring", classes: "govuk-tag--turquoise" }) }}
-              {% endset %}
-
-              {{ govukSummaryList({
-                classes: "govuk-summary-list--no-border govuk-!-margin-bottom-0",
-                rows: rows
-              }) }}
-
             </div>
           </div>
 
-        {% endfor %}
+          {% endfor %}
+        {% else %}
+
+          {% if data.teachersWithoutMentors | length > 0 %}
+
+            {{ govukWarningText({ text: "You need to assign a mentor to these ECTs:",
+            classes: "govuk-!-margin-bottom-3" }) }}
+
+            <ul class="govuk-list govuk-!-margin-bottom-6">
+            {% for teacher in data.teachersWithoutMentors %}
+              <li><a href="/teachers-without-mentors/{{ teacher.id }}" class="govuk-link--no-visited-state">{{ teacher.name }}</a></li>
+            {% endfor %}
+            </ul>
+          {% endif %}
+
+
+          {% for mentor in data.mentors | sort(false, false, "name") %}
+
+            <div class="govuk-summary-card">
+              <div class="govuk-summary-card__content">
+
+                <h2 class="govuk-heading-s govuk-!-margin-bottom-0">Mentor</h2>
+
+                {% set mentorStatusHtml %}
+                  {{ govukTag({ text: "Mentoring", classes: "govuk-tag--turquoise" }) }}
+                {% endset %}
+
+                {{ govukSummaryList({
+                  classes: "govuk-summary-list--no-border govuk-!-margin-bottom-4",
+                  rows: [
+                    {
+                      key: {
+                        html: "<a href=\"/mentors/" + mentor.id + "\" class=\"govuk-link--no-visited-state\">" + mentor.name + "</a>",
+                        classes: "govuk-!-font-weight-regular"
+                      },
+                      value: {
+                        html: mentorStatusHtml
+                      }
+                    }
+                  ]
+                }) }}
+
+                <h2 class="govuk-heading-s govuk-!-margin-bottom-0">ECTs</h2>
+
+                {% set rows = [] %}
+
+                {% for earlyCareerTeacher in mentor.earlyCareerTeachers %}
+
+                  {% set key = {html: "<a href=\"/early-career-teachers/" + earlyCareerTeacher.id + "\" class=\"govuk-link--no-visited-state\">" + earlyCareerTeacher.name + "</a>", classes: "govuk-!-font-weight-regular"} %}
+
+                  {% set valueHtml %}
+                    {% if earlyCareerTeacher.inductionStartDate %}
+                      {{ govukTag({ text: "Training", classes: "govuk-tag--turquoise" }) }}
+
+                      <p class="govuk-body govuk-!-margin-top-2">Induction started {{ earlyCareerTeacher.inductionStartDate | govukDate }}</p>
+
+                    {% else %}
+                      {{ govukTag({ text: "Eligible for training", classes: "govuk-tag--turquoise" }) }}
+                    {% endif %}
+                  {% endset %}
+
+                  {% set value = {html: valueHtml} %}
+                  {% set rows = (rows.push({key: key, value: value}), rows) %}
+                {% endfor %}
+
+                {% set mentorStatusHtml %}
+                  {{ govukTag({ text: "Mentoring", classes: "govuk-tag--turquoise" }) }}
+                {% endset %}
+
+                {{ govukSummaryList({
+                  classes: "govuk-summary-list--no-border govuk-!-margin-bottom-0",
+                  rows: rows
+                }) }}
+
+              </div>
+            </div>
+
+          {% endfor %}
+        {% endif %}
       </div>
 
     {% elseif data.show == "completed-induction" %}


### PR DESCRIPTION
This updates the prototype to show induction start dates for teachers (where they have been set), and to allow users to choose to sort the list of teachers by this date.

Additionally, where the induction start date indicates that the teacher is coming to or at the end of their induction (around the 2 year mark for the regular programme), but an induction completed date has not been recorded, it adds a message to try and explain that this is the Appropriate Body to record, and there may be a delay in the information getting to our service.

(We don't yet know how long the delay might be)

## Screenshots

### Sorted (and grouped) by mentor

![sort-by-mentor](https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/cc75faec-3fd1-4fd5-9842-6e8048fffec8)

### Sorted by induction start date

![sort-by-induction-start-date](https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/b259fba2-d308-435e-90a4-91551e0f64e9)

### ECT where they may be coming up to end of induction

<img width="816" alt="Screenshot 2023-08-17 at 15 19 11" src="https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/1100420c-8ac9-4f9c-8b63-6e436950bc37">
