### PR TITLE
Update transfer journey

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -15,3 +15,16 @@
 .govuk-summary-list__missing-heading {
   margin-bottom: 10px;
 }
+
+// This is an invisible-looking link which is only used for research
+// purposes where we want to direct participants to click some text without
+// it looking like a link.
+.govuk-link--hidden,
+.govuk-link--hidden:visited {
+  text-decoration: none;
+  color: inherit;
+}
+
+.govuk-link--hidden:hover {
+  text-decoration: underline;
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -72,12 +72,18 @@ router.get('/early-career-teachers/:id', (req, res) => {
   })
 })
 
-router.get('/teachers-without-mentors/:id', (req, res) => {
+router.get('/early-career-teachers/:id', (req, res) => {
   const { id } = req.params
 
-  const mentor = null
+  const mentor = req.session.data.mentors.find(function(mentor) {
+    return mentor.earlyCareerTeachers.find(function(teacher) {
+      return teacher.id === id
+    })
+  })
 
-  const teacher = req.session.data.teachersWithoutMentors.find(function(teacher) {
+  const teacher = req.session.data.mentors.map(function(mentor) {
+    return mentor.earlyCareerTeachers
+  }).flat().find(function(teacher) {
     return teacher.id === id
   })
 
@@ -87,6 +93,67 @@ router.get('/teachers-without-mentors/:id', (req, res) => {
     mentor
   })
 })
+
+router.get('/early-career-teachers/:id/transfer', (req, res) => {
+  const { id } = req.params
+
+  const teacher = req.session.data.mentors.map(function(mentor) {
+    return mentor.earlyCareerTeachers
+  }).flat().find(function(teacher) {
+    return teacher.id === id
+  })
+
+  res.render('transfer', {
+    id,
+    teacher
+  })
+})
+
+router.get('/early-career-teachers/:id/transfer-date', (req, res) => {
+  const { id } = req.params
+
+  const teacher = req.session.data.mentors.map(function(mentor) {
+    return mentor.earlyCareerTeachers
+  }).flat().find(function(teacher) {
+    return teacher.id === id
+  })
+
+  res.render('transfer-date', {
+    id,
+    teacher
+  })
+})
+
+router.get('/early-career-teachers/:id/transfer-check', (req, res) => {
+  const { id } = req.params
+
+  const teacher = req.session.data.mentors.map(function(mentor) {
+    return mentor.earlyCareerTeachers
+  }).flat().find(function(teacher) {
+    return teacher.id === id
+  })
+
+  res.render('transfer-check', {
+    id,
+    teacher
+  })
+})
+
+router.get('/early-career-teachers/:id/transfer-confirmed', (req, res) => {
+  const { id } = req.params
+
+  const teacher = req.session.data.mentors.map(function(mentor) {
+    return mentor.earlyCareerTeachers
+  }).flat().find(function(teacher) {
+    return teacher.id === id
+  })
+
+  res.render('transfer-confirmed', {
+    id,
+    teacher
+  })
+})
+
 
 router.get('/mentors/:id', (req, res) => {
   const { id } = req.params

--- a/app/views/check-email.html
+++ b/app/views/check-email.html
@@ -13,7 +13,7 @@
 
     <h1 class="govuk-heading-l">{{ pageName }}</h1>
 
-    <p class="govuk-body">You should have received an email sent to {{ data["email"] }} with a link to sign in.</p>
+    <p class="govuk-body">You should have received an email sent to <a class="govuk-link govuk-link--hidden" href="/participants?show=training">{{ data["email"] }}</a> with a link to sign in.</p>
 
     <p class="govuk-body">If it does not arrive within 5 minutes, check your junk folder or <a href="/sign-in" class="govuk-link">try again</a>.</p>
 

--- a/app/views/early-career-teacher.html
+++ b/app/views/early-career-teacher.html
@@ -162,11 +162,9 @@
       ]
     }) }}
 
-    <h2 class="govuk-heading-m">No longer training?</h2>
+    <h2 class="govuk-heading-m">Are they transferring to another school?</h2>
 
-    <p class="govuk-body">Tell us if <a href="#" class="govuk-link">{{ teacher.name }} is transferring to another school</a></p>
-
-    <p class="govuk-body">Contact your training provider if you wish to remove this participant.</p>
+    <p class="govuk-body">Tell us if <a href="/early-career-teachers/{{ teacher.id }}/transfer" class="govuk-link">{{ teacher.name }} is transferring to another school</a></p>
 
 
   </div>

--- a/app/views/transfer-check.html
+++ b/app/views/transfer-check.html
@@ -1,0 +1,70 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: "Manage mentors and ECTs",
+        href: "/participants?show=training"
+      },
+      {
+        text: teacher.name,
+        href: "/early-career-teachers/" + teacher.id
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">St Mary’s Primary School</span>
+    <h1 class="govuk-heading-l">Check your answers</h1>
+
+    {{ govukSummaryList({
+        classes: 'govuk-!-margin-bottom-9',
+        rows: [
+          {
+            key: {
+              text: "Name"
+            },
+            value: {
+              text: teacher.name
+            }
+          },
+          {
+            key: {
+              text: "Leaving date"
+            },
+            value: {
+              text: (data.transferDate | isoDateFromDateInput | govukDate)
+            },
+            actions: {
+              items: [
+                {
+                  href:  "/early-career-teachers/" + teacher.id + "/transfer-date",
+                  text: "Change",
+                  visuallyHiddenText: "leaving date"
+                }
+              ]
+            }
+          }
+        ]
+      }) }}
+
+    <form action="/early-career-teachers/{{ teacher.id }}/transfer-confirmed" method="post">
+      {{ govukButton({ text: "Confirm and continue"}) }}
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/transfer-confirmed.html
+++ b/app/views/transfer-confirmed.html
@@ -1,0 +1,54 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: "Manage mentors and ECTs",
+        href: "/participants?show=training"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+
+    {{ govukPanel({
+      titleText: "Transfer confirmed",
+      classes: "govuk-!-margin-bottom-7"
+    }) }}
+
+    <p class="govuk-body">You’ve confirmed that  {{ teacher.name }} is leaving St Mary’s Primary School on <span style="white-space: nowrap;">{{ data.transferDate | isoDateFromDateInput | govukDate }}</span>.</p>
+
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+    <p class="govuk-body">We’ll tell {{ teacher.name }} that you’ve reported their transfer.</p>
+
+    <p class="govuk-body">They should continue their training until they leave.
+    Their new school will arrange how they’ll continue their training.</p>
+
+    <p class="govuk-body">You should report this transfer to:</p>
+
+    <ol class="govuk-list govuk-list--bullet">
+      <li>Alban Teaching School Hub</li>
+      <li>Ambition Institute</li>
+    </ol>
+
+      <p class="govuk-body">{{ teacher.name }}’s mentor can continue their mentor training, even if they do not have another ECT assigned to them yet.</p>
+
+    <p class="govuk-body"><a class="govuk-link govuk-link govuk-link--no-visited-state" href="/participants?show=training">View your ECTs and mentors</a></p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/transfer-date.html
+++ b/app/views/transfer-date.html
@@ -1,0 +1,57 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/early-career-teachers/" + teacher.id + "/transfer"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">St Mary’s Primary School</span>
+
+    <form action="/early-career-teachers/{{ teacher.id }}/transfer-check" method="post">
+
+      {{ govukDateInput({
+        id: "transfer-date",
+        fieldset: {
+          legend: {
+            text: "When is " + teacher.name + " leaving your school?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        hint: {
+          text: "For example, 14 7 2023"
+        },
+        items: [{
+          classes: "govuk-input--width-2",
+          label: "Day",
+          name: "transferDate[day]",
+          value: data.transferDate.day
+        }, {
+          classes: "govuk-input--width-2",
+          label: "Month",
+          name: "transferDate[month]",
+          value: data.transferDate.month
+        }, {
+          classes: "govuk-input--width-4",
+          label: "Year",
+          name: "transferDate[year]",
+          value: data.transferDate.year
+        }]
+      }) }}
+
+      {{ govukButton({ text: "Continue"}) }}
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/transfer.html
+++ b/app/views/transfer.html
@@ -1,0 +1,28 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/early-career-teachers/" + teacher.id
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">St Mary’s Primary School</span>
+    <h1 class="govuk-heading-l">Is {{ teacher.name }} transferring to another school to continue training?</h1>
+
+
+    <p>If they are leaving your school for any other reason, contact your training provider instead.</p>
+
+    {{ govukButton({ text: "Yes, they are transferring", href: "/early-career-teachers/" + teacher.id + "/transfer-date"}) }}
+
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This adds the journey to the prototype where schools tell us a teacher is leaving them to continue their induction training elsewhere, and makes some design tweaks.

## Screenshots

### ECT page

<img width="1016" alt="Screenshot 2023-08-18 at 16 08 05" src="https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/be6d3515-26f7-4b43-859a-18c99f97b3db">

### Confirmation page

(Maybe we could ditch this if it’s clear enough elsewhere?)

<img width="1001" alt="Screenshot 2023-08-18 at 16 08 17" src="https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/e160a7fa-9e8b-456d-a296-ffddacb6287d">

### Leaving date page

<img width="996" alt="Screenshot 2023-08-18 at 16 09 01" src="https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/509b4070-b0ba-44a1-8cdc-6286f08067f7">

### Check your answers page

<img width="1004" alt="Screenshot 2023-08-18 at 16 09 16" src="https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/2bae0b12-185e-4c16-8576-03c529b09bb2">

### Confirmation page

<img width="996" alt="Screenshot 2023-08-18 at 16 09 45" src="https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/3b410ac4-ae85-48dd-872e-a93dc9c8b332">
