### PR TITLE
Adding content to the detailed guide

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -157,7 +157,7 @@
   <li><a class="govuk-link" href="https://www.edt.org/united-kingdom/programmes/early-career-professional-development-programme/">Education Development Trust</a></li>
   <li><a class="govuk-link" href="https://niot.org.uk/programmes/ECF">National Institute of Teaching, founded by the School-Led Development Trust</a></li>
   <li><a class="govuk-link" href="https://www.teachfirst.org.uk/early-career-framework">Teach First</a></li>
-  <li><a class="govuk-link" href="https://www.ucl.ac.uk/ioe/departments-and-centres/departments/learning-and-leadership/early-career-framework">UCL Institute of Education </a></li>
+  <li><a class="govuk-link" href="https://www.ucl.ac.uk/ioe/departments-and-centres/departments/learning-and-leadership/early-career-framework">UCL Institute of Education</a></li>
 </ul>      
 
 <p class="govuk-body">If you choose to use a lead provider, your registered induction tutor will need to report this through the [Manage training for early career teachers](#report-your-training-information-to-the-DfE) service each academic year. They do not need to tell us which provider your school will work with. Your lead provider is responsible for reporting this to us directly.</p>       
@@ -292,8 +292,8 @@
 
 <p class="govuk-body">Schools in England must use this service to:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>[nominate one person](#choose-or-change-the-registered-induction-tutor-for-your-school) as their registered user (or 'induction tutor')</li>
-  <li>report how they'll [provide ECF-based training](#choose-or-change-how-to-provide-ECF-based-training-at-your-school) for ECTs each academic year</li>
+  <li>[nominate one person](#choose-or-change-the-registered-induction-tutor-for-your-school) as their registered user (or ’induction tutor’)</li>
+  <li>report how they’ll [provide ECF-based training](#choose-or-change-how-to-provide-ECF-based-training-at-your-school) for ECTs each academic year</li>
   <li>register each ECT and their mentor</li>
   <li>report which mentor each ECT will work with to ensure the correct funding is paid</li>
   <li>report if a registered ECT or mentor [transfers to another school](#report-if-something-changes-for-an-ECT-or-mentor) in England during their ECF-based induction or training</li>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -33,10 +33,11 @@
 
       <div class="govuk-caption-l">Guidance</div>
       <h1 class="govuk-heading-l">
-        Heading goes here
+        How to manage induction, training and support for early career teachers (ECTs)
       </h1>
 
-      <p class="govuk-body-l govuk-!-margin-bottom-2">Description of page goes here</p>
+      <p class="govuk-body-l govuk-!-margin-bottom-2">Information on setting up and managing the 2-year induction for ECTs, 
+        and the DfE-funded training based on the early career framework (ECF) that’s now part of statutory induction.</p>
 
     </div>
   </div>
@@ -47,8 +48,8 @@
     <div class="govuk-grid-column-two-thirds">
 
       <p class="govuk-body-s govuk-!-margin-bottom-1">From: <a href="#"><b>Department for Education</b></a></p>
-      <p class="govuk-body-s govuk-!-margin-bottom-1">Published XX Month YYY</p>
-      <p class="govuk-body-s govuk-!-margin-bottom-1">Last updated XX Month YYY</p>
+      <p class="govuk-body-s govuk-!-margin-bottom-1">Published 24 October 2023</p>
+      <p class="govuk-body-s govuk-!-margin-bottom-1">Last updated 24 October 2023</p>
 
     </div>
   </div>
@@ -60,7 +61,138 @@
       <div class="govuk-body" style="background-color: #f3f2f1; padding: 20px 30px; font-weight: bold;">Applies to England</div>
 
 
-      <p>Content goes here.</p>
+  <p>Contents</p>
+    
+    <ul class="govuk-list">
+  <li>
+    <a class="govuk-link" href="#">Choose or change the registered induction tutor for your school</a>
+  </li>
+  <li>
+    <a class="govuk-link" href="#">Choose or change how to provide ECF-based training at your school</a>
+  </li>
+  <li>
+    <a class="govuk-link" href="#">Appoint an appropriate body</a>
+  </li>
+  <li>
+    <a class="govuk-link" href="#">Arrange mentoring</a>
+  </li>
+  <li>
+    <a class="govuk-link" href="#">Report your training information to the DfE</a>
+  </li>
+  <li>
+    <a class="govuk-link" href="#">Register ECTs and mentors</a>
+  </li>
+  <li>
+    <a class="govuk-link" href="#">Manage statutory induction and training for ECTs, including non-standard or part time inductions</a>
+  </li>
+  <li>
+    <a class="govuk-link" href="#">Report if something changes for an ECT or mentor</a>
+  </li>   
+</ul>
+
+<h2 class="govuk-heading-m">Choose or change the registered induction tutor for your school</h2>
+
+<p class="govuk-body">Induction tutors [monitor and support](/observation-and-assessment) your ECTs. They conduct:</p>      
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>regular progress reviews</li>
+  <li>2 formal assessment meetings with ECTs during the 2-year induction period - one midway through and one at the end</li>
+</ul>  
+
+<p class="govuk-body">Read about the roles and responsibilities of induction tutors in <a href="https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" class="govuk-link">section 5 of the statutory guidance on induction for ECTs</a>.</p>
+
+<p class="govuk-body">Your school may have several people performing this role, but only one can be registered to report information to the Department for Education (DfE) using the Manage training for early career teachers service.</p>      
+  
+<p class="govuk-body">Find out how to [report information to the DfE](/report-to-dfe).</p> 
+
+<h3 class="govuk-heading-s">Who to nominate</h3>
+
+<p class="govuk-body">Choose someone who:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>holds qualified teacher status (QTS)</li>
+  <li>can assess an ECT’s progress against the teachers’ standards</li>
+</ul>    
+
+<p class="govuk-body">Schools commonly choose someone in a senior leadership position, such as an assistant head.</p> 
+      
+<p class="govuk-body">Try to choose someone who is not also a mentor. The 2 roles have separate and different responsibilities.</p>
+
+<h3 class="govuk-heading-s">Nominate your first registered induction tutor</h3>      
+      
+<p class="govuk-body">Use the <a href="https://manage-training-for-early-career-teachers.education.gov.uk/nominations/resend-email" class="govuk-link">Manage training for early career teachers service</a> to do this.</p>
+    
+<p class="govuk-body">DfE will send an access link to the email address your school provided to the <a href="https://get-information-schools.service.gov.uk/" class="Get Information About Schools (GIAS)"> register.</p>    
+    
+<h3 class="govuk-heading-s">Change your current registered induction tutor</h3>
+
+<p class="govuk-body">If your current induction tutor is leaving your school, or will no longer be acting as your induction tutor, they should follow these steps.</p>  
+      
+<ol class="govuk-list govuk-list--number">
+  <li>Sign into the [Manage training for early career teachers service](/report-to-dfe) using their registered email address.</li>
+  <li>Select the ‘Change’ link next to their name.</li>
+  <li>Enter the name and email address of the person who will report information to the DfE instead.</li>
+</ol>      
+    
+<h3 class="govuk-heading-s">If your registered induction tutor has left your school, or cannot access the service</h3> 
+
+<p class="govuk-body">If no one at your school can access the Manage training for early career teachers service to change your registered induction tutor, you can [<a href="https://manage-training-for-early-career-teachers.education.gov.uk/nominations/resend-email" class="request an access link for your school"></a>.</p>       
+      
+<h2 class="govuk-heading-m">Choose or change how to provide ECF-based training at your school</h2>
+
+<p class="govuk-body">ECTs are entitled to 2 years of training based on the <a href="https://www.gov.uk/government/publications/early-career-framework" class="early career framework"></a> (ECF).</p>       
+
+<h3 class="govuk-heading-s">Option 1: use a lead provider</h3>
+
+<p class="govuk-body">Lead providers work with delivery partners such as trusts, teaching school hubs and universities to deliver training directly to your ECTs and their mentors.</p>
+
+<p class="govuk-body">This is fully funded by the DfE, so there’s no cost for eligible schools. Learn about <a href="https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training" class="funding for training based on the early career framework"></a>.</p>       
+
+<p class="govuk-body">Providers may need to use face to face sessions as part of their training, so contact them to check where they’re based before signing up.</p> 
+
+<p class="govuk-body">To sign up with a lead provider, contact them:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><a class="govuk-link" href="https://www.ambition.org.uk/programmes/early-career-teachers/?utm_source=dfe&utm_medium=pr%2Fwebsite&utm_content=NRO+announcement&utm_campaign=ECT-Marketing-2021">Ambition Institute</a></li>
+  <li><a class="govuk-link" href="https://www.bestpracticenet.co.uk/early-career-framework">Best Practice Network (home of Outstanding Leaders Partnership)</a></li>
+  <li><a class="govuk-link" href="https://www.edt.org/united-kingdom/programmes/early-career-professional-development-programme/">Education Development Trust</a></li>
+  <li><a class="govuk-link" href="https://niot.org.uk/programmes/ECF">National Institute of Teaching, founded by the School-Led Development Trust</a></li>
+  <li><a class="govuk-link" href="https://www.teachfirst.org.uk/early-career-framework">Teach First</a></li>
+  <li><a class="govuk-link" href="https://www.ucl.ac.uk/ioe/departments-and-centres/departments/learning-and-leadership/early-career-framework">UCL Institute of Education </a></li>
+</ul>      
+
+<p class="govuk-body">If you choose to use a lead provider, your registered induction tutor will need to report this through the [Manage training for early career teachers](/report-to-dfe) service each academic year. They do not need to tell us which provider your school will work with. Your lead provider is responsible for reporting this to us directly.</p>       
+
+<h3 class="govuk-heading-s">Option 2: deliver your own training using DfE-accredited materials</h3>
+
+<p class="govuk-body">DfE-accredited materials include mentor session guidelines and self-directed study materials.</p> 
+
+<p class="govuk-body">Create a <a href="https://support-for-early-career-teachers.education.gov.uk/users/sign-up" class="Support for early career teachers"></a> account to see what materials are available.</p>       
+
+<p class="govuk-body">You can choose materials from one of the following suppliers:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>Ambition Institute</li>
+  <li>Education Development Trust</li>
+  <li>Teach First</li>
+  <li>UCL Early Career Teacher Consortium</li>
+</ul>
+
+<p class="govuk-body">If you choose to deliver your own training using DfE-accredited materials, your registered induction tutor will need to report this through the [Manage training for early career teachers](/report-to-dfe) service.</p> 
+
+<p class="govuk-body">Your [appropriate body](/appoint-appropriate-body) will check your programme to make sure it covers the full depth of the early career framework.</p> 
+
+<h3 class="govuk-heading-s">Option 3: design and deliver your own training</h3> 
+
+<p class="govuk-body">You can design and deliver your own 2-year training programme covering every ‘learn that’ and ‘learn how to’ statement in the <a href="https://www.gov.uk/government/publications/early-career-framework" class="early career framework"></a>.</p>       
+
+<p class="govuk-body">You can use DfE-accredited training materials for reference. These include mentor session guidelines and self-directed study materials.</p> 
+
+<p class="govuk-body">Create a <a href="https://support-for-early-career-teachers.education.gov.uk/users/sign-up" class="Support for early career teachers"></a> account to see what materials are available.</p>  
+
+<p class="govuk-body">Talk to your [appropriate body](appoint-appropriate-body) for advice on next steps.</p> 
+
+<p class="govuk-body">Your appropriate body will check your programme to make sure it covers the early career framework.</p>
+
+<p class="govuk-body">Avoid changing your training option part early career framework. way through induction.</p>       
+      
     </div>
 
     <div class="govuk-grid-column-one-third">

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -137,7 +137,8 @@
 
 <p class="govuk-body">If no one at your school can access the Manage training for early career teachers service to change your registered induction tutor, you can [<a href="https://manage-training-for-early-career-teachers.education.gov.uk/nominations/resend-email" class="request an access link for your school"></a>.</p>       
       
-<h2 class="govuk-heading-m">Choose or change how to provide ECF-based training at your school</h2>
+
+      <h2 class="govuk-heading-m">Choose or change how to provide ECF-based training at your school</h2>
 
 <p class="govuk-body">ECTs are entitled to 2 years of training based on the <a href="https://www.gov.uk/government/publications/early-career-framework" class="early career framework"></a> (ECF).</p>       
 
@@ -191,7 +192,97 @@
 
 <p class="govuk-body">Your appropriate body will check your programme to make sure it covers the early career framework.</p>
 
-<p class="govuk-body">Avoid changing your training option part early career framework. way through induction.</p>       
+<p class="govuk-body">Avoid changing your training option part early career framework. way through induction.</p>    
+
+
+  <h2 class="govuk-heading-m">Appoint an appropriate body </h2>
+
+<p class="govuk-body">ECTs cannot start their induction until you’ve appointed an appropriate body.</p>
+
+<h3 class="govuk-heading-s">What an appropriate body does</h3>
+
+<p class="govuk-body">Appropriate bodies quality assure the induction of ECTs. For example, they:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>check that your ECTs receive their statutory entitlements, such as [mentoring](/mentoring) throughout their 2-year induction period</li>
+  <li>make sure [formal assessments](/observation-and-assessment) conducted by your induction tutor are fair and appropriate </li>
+</ul>      
+
+<p class="govuk-body">Unless you use a [training provider](/training-options) to deliver your training, your appropriate body will also check that your training covers the full depth of the <a href="https://www.gov.uk/government/publications/early-career-framework" class="early career framework"></a>.</p>       
+
+<p class="govuk-body">Your appropriate body can also give advice if your ECTs are [serving a reduced or part time induction](/observation-and-assessment). They’ll need to agree to any reduction to the induction period.</p>  
+
+<p class="govuk-body">You must provide each ECT with contact information for their appropriate body.</p>
+
+<h3 class="govuk-heading-s">Find an appropriate body</h3>
+
+<p class="govuk-body"><a href="https://www.gov.uk/government/publications/statutory-teacher-induction-appropriate-bodies/find-an-appropriate-body" class="Find an appropriate body"></a> and contact them to appoint them.</p>      
+
+<h3 class="govuk-heading-s">Who you can and cannot appoint</h3>
+
+<p class="govuk-body">You can appoint one appropriate body for all of your ECTs, but you may need or choose to appoint different ones.</p> 
+      
+<p class="govuk-body">You may have previously used a local authority as an appropriate body. From September 2023, you cannot use a local authority for new inductions, so you’ll need to choose another appropriate body for any new ECTs.</p> 
+
+<p class="govuk-body">If an ECT did their initial teacher training (ITT) through an accredited ITT provider who is also an appropriate body, you cannot appoint that appropriate body for that teacher.</p> 
+
+<p class="govuk-body">ECTs may be serving their induction at an appropriate body. For example, they may work at a teaching school hub that is also an appropriate body. If this is the case, you cannot appoint that appropriate body for that teacher.</p> 
+
+<p class="govuk-body">Learn more about who you can and cannot appoint in section 2 of the <a href="https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" class="statutory guidance on induction for early career teachers"></a>.</p> 
+
+
+<h2 class="govuk-heading-m">Arrange mentoring</h2>      
+
+<p class="govuk-body">ECTs are entitled to mentor support throughout their 2-year induction period.</p>
+
+<p class="govuk-body">Mentors will only be <a href="https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training" class="eligible for funded training and time off timetable"></a> once they’re assigned to an ECT in the DfE service. Find out [how to register and assign mentors](/register-ects-and-mentors).      
+      
+<h3 class="govuk-heading-s">What mentors do</h3> 
+
+<p class="govuk-body">Mentors make sure that your ECTs receive a high quality induction. They:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>meet regularly with ECTs to provide support and feedback</li>
+  <li>take prompt, appropriate action if their ECT is experiencing difficulties</li>
+</ul>
+    
+<p class="govuk-body">If you [use a provider](/training-options#use-a-lead-provider) to deliver your training, mentors may also be asked to observe your ECTs. This is for professional development purposes and must not be used for formal assessment.</p> 
+
+<p class="govuk-body">Read about the role and responsibilities of mentors in <a href="https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" class="section 5 of the statutory guidance on induction for early career teachers"></a>.</p> 
+
+<p class="govuk-body">Share the <a href="https://www.gov.uk/guidance/guidance-for-mentors-how-to-support-ecf-based-training" class="guidance for mentors"></a> to help them understand their role.</p> 
+
+<h3 class="govuk-heading-s">Who to choose as a mentor</h3> 
+
+<p class="govuk-body">Choose mentors who have the skills to provide mentoring for specific phases and subject areas. This will normally be someone who has qualified teacher status (QTS).</p>       
+      
+<p class="govuk-body">If you choose someone who does not have qualified teacher status, you should check this decision with your [appropriate body](appoint-appropriate-body).</p>
+
+<p class="govuk-body">Try to choose someone who is not also the [induction tutor](/induction-tutor). The 2 roles have separate and different responsibilities.</p>
+
+<h3 class="govuk-heading-s">Manage mentor time</h3>
+
+<p class="govuk-body">Timetable mentor sessions during teaching hours wherever possible. Make sure your mentors have enough time to meet with their ECTs regularly.</p>
+
+<p class="govuk-body">Schools receive <a href="https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training" class="funding to cover mentor time off timetable"></a>.</p>       
+
+<h3 class="govuk-heading-s">Mentor training</h3>    
+
+<p class="govuk-body">If you use a training provider to deliver training for your ECTs, mentors will be given 36 hours of training over 2 years.</p> 
+
+<p class="govuk-body">Schools receive funding for 36 hours of mentor time off timetable if mentors attend this training. <a href="https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training" class="Learn more about funding"></a></p>.  
+      
+<p class="govuk-body">Mentors can only do this training and receive funded time off timetable for this training once. However, they can keep being a mentor as many times as they like.</p>
+
+<p class="govuk-body">Mentors can continue their training even if their ECT leaves your school or withdraws part way through their induction.</p>
+
+<h3 class="govuk-heading-s">Mentor concerns</h3>
+
+<p class="govuk-body">If a mentor has concerns or difficulties, they should contact your school’s induction tutor.</p>
+
+<p class="govuk-body">If a mentor does not have the time or ability to carry out their role effectively, talk to your appropriate body.</p>
+
+      
+
+      
       
     </div>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -90,9 +90,9 @@
   </li>   
 </ul>
 
-<h2 class="govuk-heading-m">Choose or change the registered induction tutor for your school</h2>
+  <h2 class="govuk-heading-m">Choose or change the registered induction tutor for your school</h2>
 
-<p class="govuk-body">Induction tutors [monitor and support](/observation-and-assessment) your ECTs. They conduct:</p>      
+<p class="govuk-body">Induction tutors [monitor and support](#manage-statutory-induction-and-training-for-ECTs) your ECTs. They conduct:</p>      
 
 <ul class="govuk-list govuk-list--bullet">
   <li>regular progress reviews</li>
@@ -103,7 +103,7 @@
 
 <p class="govuk-body">Your school may have several people performing this role, but only one can be registered to report information to the Department for Education (DfE) using the Manage training for early career teachers service.</p>      
   
-<p class="govuk-body">Find out how to [report information to the DfE](/report-to-dfe).</p> 
+<p class="govuk-body">Find out how to [report information to the DfE](#report-your-training-information-to-the-DfE).</p> 
 
 <h3 class="govuk-heading-s">Who to nominate</h3>
 
@@ -128,7 +128,7 @@
 <p class="govuk-body">If your current induction tutor is leaving your school, or will no longer be acting as your induction tutor, they should follow these steps.</p>  
       
 <ol class="govuk-list govuk-list--number">
-  <li>Sign into the [Manage training for early career teachers service](/report-to-dfe) using their registered email address.</li>
+  <li>Sign into the [Manage training for early career teachers service](#report-your-training-information-to-the-DfE) using their registered email address.</li>
   <li>Select the ‘Change’ link next to their name.</li>
   <li>Enter the name and email address of the person who will report information to the DfE instead.</li>
 </ol>      
@@ -160,7 +160,7 @@
   <li><a class="govuk-link" href="https://www.ucl.ac.uk/ioe/departments-and-centres/departments/learning-and-leadership/early-career-framework">UCL Institute of Education </a></li>
 </ul>      
 
-<p class="govuk-body">If you choose to use a lead provider, your registered induction tutor will need to report this through the [Manage training for early career teachers](/report-to-dfe) service each academic year. They do not need to tell us which provider your school will work with. Your lead provider is responsible for reporting this to us directly.</p>       
+<p class="govuk-body">If you choose to use a lead provider, your registered induction tutor will need to report this through the [Manage training for early career teachers](#report-your-training-information-to-the-DfE) service each academic year. They do not need to tell us which provider your school will work with. Your lead provider is responsible for reporting this to us directly.</p>       
 
 <h3 class="govuk-heading-s">Option 2: deliver your own training using DfE-accredited materials</h3>
 
@@ -176,9 +176,9 @@
   <li>UCL Early Career Teacher Consortium</li>
 </ul>
 
-<p class="govuk-body">If you choose to deliver your own training using DfE-accredited materials, your registered induction tutor will need to report this through the [Manage training for early career teachers](/report-to-dfe) service.</p> 
+<p class="govuk-body">If you choose to deliver your own training using DfE-accredited materials, your registered induction tutor will need to report this through the [Manage training for early career teachers](#report-your-training-information-to-the-DfE) service.</p> 
 
-<p class="govuk-body">Your [appropriate body](/appoint-appropriate-body) will check your programme to make sure it covers the full depth of the early career framework.</p> 
+<p class="govuk-body">Your [appropriate body](#appoint-an-appropriate-body) will check your programme to make sure it covers the full depth of the early career framework.</p> 
 
 <h3 class="govuk-heading-s">Option 3: design and deliver your own training</h3> 
 
@@ -188,7 +188,7 @@
 
 <p class="govuk-body">Create a <a href="https://support-for-early-career-teachers.education.gov.uk/users/sign-up" class="Support for early career teachers"></a> account to see what materials are available.</p>  
 
-<p class="govuk-body">Talk to your [appropriate body](appoint-appropriate-body) for advice on next steps.</p> 
+<p class="govuk-body">Talk to your [appropriate body](#appoint-an-appropriate-body) for advice on next steps.</p> 
 
 <p class="govuk-body">Your appropriate body will check your programme to make sure it covers the early career framework.</p>
 
@@ -203,13 +203,13 @@
 
 <p class="govuk-body">Appropriate bodies quality assure the induction of ECTs. For example, they:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>check that your ECTs receive their statutory entitlements, such as [mentoring](/mentoring) throughout their 2-year induction period</li>
-  <li>make sure [formal assessments](/observation-and-assessment) conducted by your induction tutor are fair and appropriate </li>
+  <li>check that your ECTs receive their statutory entitlements, such as [mentoring](#arrange-mentoring) throughout their 2-year induction period</li>
+  <li>make sure [formal assessments](#manage-statutory-induction-and-training-for-ECTs) conducted by your induction tutor are fair and appropriate</li>
 </ul>      
 
-<p class="govuk-body">Unless you use a [training provider](/training-options) to deliver your training, your appropriate body will also check that your training covers the full depth of the <a href="https://www.gov.uk/government/publications/early-career-framework" class="early career framework"></a>.</p>       
+<p class="govuk-body">Unless you use a [training provider](#choose-or-change-how-to-provide-ECF-based-training-at-your-school) to deliver your training, your appropriate body will also check that your training covers the full depth of the <a href="https://www.gov.uk/government/publications/early-career-framework" class="early career framework"></a>.</p>       
 
-<p class="govuk-body">Your appropriate body can also give advice if your ECTs are [serving a reduced or part time induction](/observation-and-assessment). They’ll need to agree to any reduction to the induction period.</p>  
+<p class="govuk-body">Your appropriate body can also give advice if your ECTs are [serving a reduced or part time induction](#manage-statutory-induction-and-training-for-ECTs). They’ll need to agree to any reduction to the induction period.</p>  
 
 <p class="govuk-body">You must provide each ECT with contact information for their appropriate body.</p>
 
@@ -230,11 +230,11 @@
 <p class="govuk-body">Learn more about who you can and cannot appoint in section 2 of the <a href="https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" class="statutory guidance on induction for early career teachers"></a>.</p> 
 
 
-<h2 class="govuk-heading-m">Arrange mentoring</h2>      
+  <h2 class="govuk-heading-m">Arrange mentoring</h2>      
 
 <p class="govuk-body">ECTs are entitled to mentor support throughout their 2-year induction period.</p>
 
-<p class="govuk-body">Mentors will only be <a href="https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training" class="eligible for funded training and time off timetable"></a> once they’re assigned to an ECT in the DfE service. Find out [how to register and assign mentors](/register-ects-and-mentors).      
+<p class="govuk-body">Mentors will only be <a href="https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training" class="eligible for funded training and time off timetable"></a> once they’re assigned to an ECT in the DfE service. Find out [how to register and assign mentors](#choose-or-change-how-to-provide-ECF-based-training-at-your-school).      
       
 <h3 class="govuk-heading-s">What mentors do</h3> 
 
@@ -244,7 +244,7 @@
   <li>take prompt, appropriate action if their ECT is experiencing difficulties</li>
 </ul>
     
-<p class="govuk-body">If you [use a provider](/training-options#use-a-lead-provider) to deliver your training, mentors may also be asked to observe your ECTs. This is for professional development purposes and must not be used for formal assessment.</p> 
+<p class="govuk-body">If you [use a provider](#choose-or-change-how-to-provide-ECF-based-training-at-your-school) to deliver your training, mentors may also be asked to observe your ECTs. This is for professional development purposes and must not be used for formal assessment.</p> 
 
 <p class="govuk-body">Read about the role and responsibilities of mentors in <a href="https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" class="section 5 of the statutory guidance on induction for early career teachers"></a>.</p> 
 
@@ -254,9 +254,9 @@
 
 <p class="govuk-body">Choose mentors who have the skills to provide mentoring for specific phases and subject areas. This will normally be someone who has qualified teacher status (QTS).</p>       
       
-<p class="govuk-body">If you choose someone who does not have qualified teacher status, you should check this decision with your [appropriate body](appoint-appropriate-body).</p>
+<p class="govuk-body">If you choose someone who does not have qualified teacher status, you should check this decision with your [appropriate body](#appoint-an-appropriate-body).</p>
 
-<p class="govuk-body">Try to choose someone who is not also the [induction tutor](/induction-tutor). The 2 roles have separate and different responsibilities.</p>
+<p class="govuk-body">Try to choose someone who is not also the [induction tutor](#choose-or-change-the-registered-induction-tutor-for-your-school). The 2 roles have separate and different responsibilities.</p>
 
 <h3 class="govuk-heading-s">Manage mentor time</h3>
 
@@ -280,7 +280,8 @@
 
 <p class="govuk-body">If a mentor does not have the time or ability to carry out their role effectively, talk to your appropriate body.</p>
 
-   <h2 class="govuk-heading-m">Report your training information to the DfE</h2>      
+  
+      <h2 class="govuk-heading-m">Report your training information to the DfE</h2>      
 
 <p class="govuk-body">Use the Manage training for early career teachers service to:</p>
 <ul class="govuk-list govuk-list--bullet">
@@ -291,14 +292,14 @@
 
 <p class="govuk-body">Schools in England must use this service to:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>[nominate one person](/induction-tutor) as their registered user (or 'induction tutor')</li>
-  <li>report how they'll [provide ECF-based training](/training-options) for ECTs each academic year</li>
+  <li>[nominate one person](#choose-or-change-the-registered-induction-tutor-for-your-school) as their registered user (or 'induction tutor')</li>
+  <li>report how they'll [provide ECF-based training](#choose-or-change-how-to-provide-ECF-based-training-at-your-school) for ECTs each academic year</li>
   <li>register each ECT and their mentor</li>
   <li>report which mentor each ECT will work with to ensure the correct funding is paid</li>
-  <li>report if a registered ECT or mentor [transfers to another school](/report-change) in England during their ECF-based induction or training</li>
+  <li>report if a registered ECT or mentor [transfers to another school](#report-if-something-changes-for-an-ECT-or-mentor) in England during their ECF-based induction or training</li>
 </ul>  
       
-<p class="govuk-body">Your school will need to provide some of this information to your [appropriate body](/appoint-appropriate-body) and [training provider](/training-option#use-a-lead-provider) too, if you work with one.</p>
+<p class="govuk-body">Your school will need to provide some of this information to your [appropriate body](#appoint-an-appropriate-body) and [training provider](#choose-or-change-how-to-provide-ECF-based-training-at-your-school) too, if you work with one.</p>
 
 <a href="https://manage-training-for-early-career-teachers.education.gov.uk/users/signed-out" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
   Start now
@@ -308,7 +309,8 @@
 
 <p class="govuk-body">If you have problems accessing or using the service, email continuing-professional-development@digital.education.gov.uk for help.</p> 
       
-  <h2 class="govuk-heading-m">Register ECTs and mentors</h2> 
+  
+      <h2 class="govuk-heading-m">Register ECTs and mentors</h2> 
 
 <p class="govuk-body">ECTs and mentors taking part in ECF-based training must be registered with the DfE if your school:</p>
 <ul class="govuk-list govuk-list--bullet">
@@ -316,7 +318,7 @@
   <li>delivers your own training using DfE-accredited materials</li>
 </ul>
 
-<p class="govuk-body">We need this information to confirm their [eligibility for funding](/funding-eligibility), and arrange access to training and materials.</p> 
+<p class="govuk-body">We need this information to confirm their [<a href="https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training" class="eligibility for funding"></a>, and arrange access to training and materials.</p> 
 
 <p class="govuk-body">Your school does not need to register ECTs and mentors with the DfE if you choose to:</p>
 <ul class="govuk-list govuk-list--bullet">
@@ -326,7 +328,7 @@
 
 <h3 class="govuk-heading-s">How to register an ECT or mentor with the DfE</h3>
 
-<p class="govuk-body">Your school’s [registered induction tutor](/induction-tutor) must [sign into the Manage training for early career teachers service](/report-to-dfe) to register each ECT and mentor.</p>
+<p class="govuk-body">Your school’s [registered induction tutor](#choose-or-change-the-registered-induction-tutor-for-your-school) must [sign into the Manage training for early career teachers service](#report-your-training-information-to-the-DfE) to register each ECT and mentor.</p>
 
 <p class="govuk-body">You’ll be asked to enter their:</p>
 <ul class="govuk-list govuk-list--bullet">
@@ -341,22 +343,23 @@
       
 <h3 class="govuk-heading-s">Assign each ECT a mentor</h3>
 
-<p class="govuk-body">Your school’s registered induction tutor must also use the [Manage training for early career teachers service](/report-to-dfe) to tell us which mentor will work with each ECT. This is an important step to make sure that relevant funding is paid.</p>
+<p class="govuk-body">Your school’s registered induction tutor must also use the [Manage training for early career teachers service](#report-your-training-information-to-the-DfE) to tell us which mentor will work with each ECT. This is an important step to make sure that relevant funding is paid.</p>
 
-<p class="govuk-body">Find out [how mentoring ECTs works](/mentoring).</p>       
+<p class="govuk-body">Find out [how mentoring ECTs works](#arrange-mentoring).</p>       
       
-    <h2 class="govuk-heading-m">Manage statutory induction and training for ECTs, including non-standard and part time inductions</h2> 
+   
+      <h2 class="govuk-heading-m">Manage statutory induction and training for ECTs</h2> 
 
 <p class="govuk-body">Throughout statutory induction you must:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>arrange for each ECT’s teaching to be observed at regular intervals</li>
   <li>make sure ECTs and mentors have adequate time off timetable to participate fully in ECF-based training and mentoring</li>
-  <li>following any other instructions from your [appropriate body](/appoint-appropriate-body) or [training provider](/training-option#use-a-lead-provider)</li>
+  <li>following any other instructions from your [appropriate body](#appoint-an-appropriate-body) or [training provider](#choose-or-change-how-to-provide-ECF-based-training-at-your-school)</li>
 </ul>      
       
 <p class="govuk-body">In terms 1, 2, 4 and 5 of a standard 2-year induction, you must arrange progress reviews against the <a href="https://www.gov.uk/government/publications/teachers-standards" class="Teachers’ Standards"></a> for each ECT.</p> 
 
-<p class="govuk-body">In terms 3 and 6 of a standard 2-year induction, you must arrange for each ECT to be formally assessed by your school’s [induction tutor](/induction-tutor) or headteacher.</p> 
+<p class="govuk-body">In terms 3 and 6 of a standard 2-year induction, you must arrange for each ECT to be formally assessed by your school’s [induction tutor](#choose-or-change-the-registered-induction-tutor-for-your-school) or headteacher.</p> 
 
 <p class="govuk-body"><a href="https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" class="See section 2 of the statutory guidance"></a> for information on how to complete these tasks.</p> 
 
@@ -374,26 +377,27 @@
   <li>any other instructions from your appropriate body or training provider</li>
 </ul>
 
-<p class="govuk-body">You do not need to withdraw or delete their information from the [DfE service](/report-to-dfe). Your training provider and appropriate body will confirm that they’ve completed training and induction, and we’ll update their records for you.</p>       
+<p class="govuk-body">You do not need to withdraw or delete their information from the [DfE service](#report-your-training-information-to-the-DfE). Your training provider and appropriate body will confirm that they’ve completed training and induction, and we’ll update their records for you.</p>       
 
 <h3 class="govuk-heading-s">For ECTs starting their induction and ECF-based training in the next academic year</h3>
 
 <p class="govuk-body">You must:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>[appoint an appropriate body](/appoint-appropriate-body) for each ECT</li>
+  <li>[appoint an appropriate body](#appoint-an-appropriate-body) for each ECT</li>
   <li>if you want to work with a training provider, contact them to confirm their availability for the next academic year</li>
 </ul>      
 
-<p class="govuk-body">DfE will contact your school in the summer term when it’s time to sign in to the DfE service and [report your training information](/report-to-dfe) for the next academic year.</p>
+<p class="govuk-body">DfE will contact your school in the summer term when it’s time to sign in to the DfE service and [report your training information](#report-your-training-information-to-the-DfE) for the next academic year.</p>
 
-    <h2 class="govuk-heading-m">Report if something changes for an ECT or mentor</h2>   
+   
+      <h2 class="govuk-heading-m">Report if something changes for an ECT or mentor</h2>   
       
-<p class="govuk-body">Your school’s [registered induction tutor](/induction-tutor) should [sign in to the DfE service](/report-to-dfe) to report if:</p>
+<p class="govuk-body">Your school’s [registered induction tutor](#choose-or-change-the-registered-induction-tutor-for-your-school) should [sign in to the DfE service](#report-your-training-information-to-the-DfE) to report if:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>a new ECT or mentor begins their induction or ECF-based training part-way through the year</li>
   <li>an ECT or mentor transfers to your school, or moves to another school, part-way through their induction or ECF-based training</li>
   <li>you no longer expect any ECTs to start their statutory induction at your school that year</li>
-  <li>the headteacher wants someone else to be registered as your school’s [induction tutor](/induction-tutor) instead (it’s important to do this before you leave your role or the school)</li>
+  <li>the headteacher wants someone else to be registered as your school’s induction tutor instead (it’s important to do this before you leave your role or the school)</li>
   <li>an ECT or mentor’s name or email address changes</li>
 </ul>
 
@@ -411,8 +415,8 @@
       
 <p class="govuk-body">Email us if you want to change your:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>[ECF-based training option](/training-options)  </li>
-  <li>[DfE-accredited training materials](/training-options#deliver-your-own-training)</li>
+  <li>[ECF-based training option](#choose-or-change-how-to-provide-ECF-based-training-at-your-school)</li>
+  <li>DfE-accredited training materials</li>
 </ul>     
 
 <p class="govuk-body">Email: continuing-professional-development@digital.education.gov.uk</p> 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -83,7 +83,7 @@
     <a class="govuk-link" href="#">Register ECTs and mentors</a>
   </li>
   <li>
-    <a class="govuk-link" href="#">Manage statutory induction and training for ECTs, including non-standard or part time inductions</a>
+    <a class="govuk-link" href="#">Manage statutory induction and training for ECTs, including non-standard and part time inductions</a>
   </li>
   <li>
     <a class="govuk-link" href="#">Report if something changes for an ECT or mentor</a>
@@ -195,7 +195,7 @@
 <p class="govuk-body">Avoid changing your training option part early career framework. way through induction.</p>    
 
 
-  <h2 class="govuk-heading-m">Appoint an appropriate body </h2>
+  <h2 class="govuk-heading-m">Appoint an appropriate body</h2>
 
 <p class="govuk-body">ECTs cannot start their induction until you’ve appointed an appropriate body.</p>
 
@@ -280,9 +280,142 @@
 
 <p class="govuk-body">If a mentor does not have the time or ability to carry out their role effectively, talk to your appropriate body.</p>
 
-      
+   <h2 class="govuk-heading-m">Report your training information to the DfE</h2>      
 
+<p class="govuk-body">Use the Manage training for early career teachers service to:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>check if ECTs are eligible to serve statutory induction, and receive <a href="https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training" class="DfE funding for training and support"></a> based on the early career framework (ECF)</li>
+  <li>check if mentors working with ECTs are eligible for DfE funding for ECF-based training and time off timetable</li>
+  <li>get access to ECF-based training materials for ECTs and their mentors</li>
+</ul>      
+
+<p class="govuk-body">Schools in England must use this service to:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>[nominate one person](/induction-tutor) as their registered user (or 'induction tutor')</li>
+  <li>report how they'll [provide ECF-based training](/training-options) for ECTs each academic year</li>
+  <li>register each ECT and their mentor</li>
+  <li>report which mentor each ECT will work with to ensure the correct funding is paid</li>
+  <li>report if a registered ECT or mentor [transfers to another school](/report-change) in England during their ECF-based induction or training</li>
+</ul>  
       
+<p class="govuk-body">Your school will need to provide some of this information to your [appropriate body](/appoint-appropriate-body) and [training provider](/training-option#use-a-lead-provider) too, if you work with one.</p>
+
+<a href="https://manage-training-for-early-career-teachers.education.gov.uk/users/signed-out" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+  Start now
+  <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+    <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+  </svg></a>
+
+<p class="govuk-body">If you have problems accessing or using the service, email continuing-professional-development@digital.education.gov.uk for help.</p> 
+      
+  <h2 class="govuk-heading-m">Register ECTs and mentors</h2> 
+
+<p class="govuk-body">ECTs and mentors taking part in ECF-based training must be registered with the DfE if your school:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>uses a training provider funded by the DfE</li>
+  <li>delivers your own training using DfE-accredited materials</li>
+</ul>
+
+<p class="govuk-body">We need this information to confirm their [eligibility for funding](/funding-eligibility), and arrange access to training and materials.</p> 
+
+<p class="govuk-body">Your school does not need to register ECTs and mentors with the DfE if you choose to:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>design and deliver your own training</li>
+  <li>work with a training provider funded directly by your school (if your school is <a href="https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training" class="not eligible for DfE-funded training"></a>, for example)</li>
+</ul>
+
+<h3 class="govuk-heading-s">How to register an ECT or mentor with the DfE</h3>
+
+<p class="govuk-body">Your school’s [registered induction tutor](/induction-tutor) must [sign into the Manage training for early career teachers service](/report-to-dfe) to register each ECT and mentor.</p>
+
+<p class="govuk-body">You’ll be asked to enter their:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>full name</li>
+  <li><a href="https://www.gov.uk/guidance/teacher-reference-number-trn" class="teacher reference number"></a></li>
+  <li>date of birth</li>
+  <li>email address (personal or school)</li>
+  <li>start date at your school, if they’re moving from another school</li>
+</ul>      
+
+<p class="govuk-body">If your school does not have this information, contact the person directly to ask for it.</p>       
+      
+<h3 class="govuk-heading-s">Assign each ECT a mentor</h3>
+
+<p class="govuk-body">Your school’s registered induction tutor must also use the [Manage training for early career teachers service](/report-to-dfe) to tell us which mentor will work with each ECT. This is an important step to make sure that relevant funding is paid.</p>
+
+<p class="govuk-body">Find out [how mentoring ECTs works](/mentoring).</p>       
+      
+    <h2 class="govuk-heading-m">Manage statutory induction and training for ECTs, including non-standard and part time inductions</h2> 
+
+<p class="govuk-body">Throughout statutory induction you must:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>arrange for each ECT’s teaching to be observed at regular intervals</li>
+  <li>make sure ECTs and mentors have adequate time off timetable to participate fully in ECF-based training and mentoring</li>
+  <li>following any other instructions from your [appropriate body](/appoint-appropriate-body) or [training provider](/training-option#use-a-lead-provider)</li>
+</ul>      
+      
+<p class="govuk-body">In terms 1, 2, 4 and 5 of a standard 2-year induction, you must arrange progress reviews against the <a href="https://www.gov.uk/government/publications/teachers-standards" class="Teachers’ Standards"></a> for each ECT.</p> 
+
+<p class="govuk-body">In terms 3 and 6 of a standard 2-year induction, you must arrange for each ECT to be formally assessed by your school’s [induction tutor](/induction-tutor) or headteacher.</p> 
+
+<p class="govuk-body"><a href="https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" class="See section 2 of the statutory guidance"></a> for information on how to complete these tasks.</p> 
+
+<h3 class="govuk-heading-s">Adapting training and induction for ECTs working part time, or completing a reduced induction</h3> 
+
+<p class="govuk-body">If any ECTs are serving a reduced or part-time induction at your school, your headteacher and appropriate body should decide on the best ECF-based training, progress review and assessment schedule for them. This must also be shared with your training provider if you work with one.</p> 
+
+<p class="govuk-body">See guidance on <a href="https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training" class="proportionate funding"></a> for these ECTs.</p> 
+
+<h3 class="govuk-heading-s">For ECTs completing their induction and ECF-based training</h3>
+
+<p class="govuk-body">Follow:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>your appropriate body’s instructions to submit a final assessment for each ECT</li>
+  <li>any other instructions from your appropriate body or training provider</li>
+</ul>
+
+<p class="govuk-body">You do not need to withdraw or delete their information from the [DfE service](/report-to-dfe). Your training provider and appropriate body will confirm that they’ve completed training and induction, and we’ll update their records for you.</p>       
+
+<h3 class="govuk-heading-s">For ECTs starting their induction and ECF-based training in the next academic year</h3>
+
+<p class="govuk-body">You must:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>[appoint an appropriate body](/appoint-appropriate-body) for each ECT</li>
+  <li>if you want to work with a training provider, contact them to confirm their availability for the next academic year</li>
+</ul>      
+
+<p class="govuk-body">DfE will contact your school in the summer term when it’s time to sign in to the DfE service and [report your training information](/report-to-dfe) for the next academic year.</p>
+
+    <h2 class="govuk-heading-m">Report if something changes for an ECT or mentor</h2>   
+      
+<p class="govuk-body">Your school’s [registered induction tutor](/induction-tutor) should [sign in to the DfE service](/report-to-dfe) to report if:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>a new ECT or mentor begins their induction or ECF-based training part-way through the year</li>
+  <li>an ECT or mentor transfers to your school, or moves to another school, part-way through their induction or ECF-based training</li>
+  <li>you no longer expect any ECTs to start their statutory induction at your school that year</li>
+  <li>the headteacher wants someone else to be registered as your school’s [induction tutor](/induction-tutor) instead (it’s important to do this before you leave your role or the school)</li>
+  <li>an ECT or mentor’s name or email address changes</li>
+</ul>
+
+<h3 class="govuk-heading-s">If your school works with a training provider</h3>
+
+<p class="govuk-body">Contact them directly to:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>tell them you want to work with a different training provider instead (they’ll report this to us)</li>
+  <li>withdraw or defer an ECT or mentor who has left teaching, is taking a break, or takes a teaching job outside of England (for ECTs, you must report this to their appropriate body too)</li>
+  <li>you no longer expect any ECTs to start their statutory induction at your school that year</li>
+  <li>reinstate an ECT or mentor who was previously withdrawn from training</li>
+</ul>     
+
+<h3 class="govuk-heading-s">When to contact the DfE support team</h3>      
+      
+<p class="govuk-body">Email us if you want to change your:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>[ECF-based training option](/training-options)  </li>
+  <li>[DfE-accredited training materials](/training-options#deliver-your-own-training)</li>
+</ul>     
+
+<p class="govuk-body">Email: continuing-professional-development@digital.education.gov.uk</p> 
       
     </div>
 


### PR DESCRIPTION
I've added content based on this draft: https://educationgovuk.sharepoint.com/:w:/r/sites/TeacherServices/Shared%20Documents/Teacher%20Continuous%20Professional%20Development/Teacher%20CPD%20Team/13.%20Schools%20and%20Teachers%20Team/Content%20Design%20and%20comms%20strategy%202023/GOV.UK%20guidance/How_to_guidance%20for%20testing%20October%2023.docx?d=w4d44486240c44eec8eedd9b973f6e617&csf=1&web=1&e=Ewszze