### PR TITLE
Add validation errors to admin UI

### DIFF
--- a/app/assets/sass/_primary-navigation.scss
+++ b/app/assets/sass/_primary-navigation.scss
@@ -8,3 +8,24 @@
   padding-left: 0;
   padding-right: 0;
 }
+
+.app-primary-navigation--wide .govuk-width-container {
+  @media (min-width: 1280px) {
+    max-width: 1250px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.app-primary-navigation--shorter .x-govuk-primary-navigation__item {
+  height: 40px;
+}
+
+.app-primary-navigation--shorter .x-govuk-primary-navigation__item,
+.app-primary-navigation--shorter .x-govuk-primary-navigation__link {
+  line-height: 40px;
+}
+
+.app-primary-navigation--less-padding .x-govuk-primary-navigation__item {
+  margin-right: 20px;
+}

--- a/app/assets/sass/_width-container.scss
+++ b/app/assets/sass/_width-container.scss
@@ -1,0 +1,8 @@
+
+.app-width-container--wide {
+  @media (min-width: 1280px) {
+    max-width: 1250px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -11,8 +11,14 @@
 @import "_primary-navigation";
 @import "_phase-banner";
 @import "_table";
+@import "_width-container";
 
 
 .app-id {
   color: $govuk-secondary-text-colour;
+}
+
+.app-user-input-example {
+  padding: 4px 8px;
+  background-color: govuk-colour("light-grey");
 }

--- a/app/assets/sass/header.scss
+++ b/app/assets/sass/header.scss
@@ -9,3 +9,11 @@
   height: 10px;
   background-color:  govuk-colour("blue");
 }
+
+.app-header--wide .govuk-width-container {
+  @media (min-width: 1280px) {
+    max-width: 1250px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/app/views/admin/index.html
+++ b/app/views/admin/index.html
@@ -1,0 +1,20 @@
+{% extends "layouts/admin.html" %}
+
+{% set pageName="" %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Overview</h1>
+    
+    <p>[Table of stats]</p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/admin/performance.html
+++ b/app/views/admin/performance.html
@@ -1,0 +1,23 @@
+{% extends "layouts/admin.html" %}
+
+{% set pageName="Performance" %}
+{% set currentSection="performance" %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    
+    <h1 class="govuk-heading-l"> {{ pageName }}</h1>
+    
+    <ul class="govuk-list">
+      <li><a href="/admin/performance/errors" class="govuk-link">Validation errors</a></li>
+    </ul>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/admin/performance/errors.html
+++ b/app/views/admin/performance/errors.html
@@ -1,0 +1,66 @@
+{% extends "layouts/admin.html" %}
+
+{% set pageName="Validation errors" %}
+{% set currentSection="performance" %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Performance",
+        href: "/admin/performance"
+      }
+    ]
+    
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    
+    <h1 class="govuk-heading-l"> {{ pageName }}</h1>
+    
+    {% set data = [
+      ["Add mentor - TRN", "Teacher reference number", "Enter the teacher reference number (TRN)", 52],
+      ["Add ECT - Name", "Name", "Enter a full name",28],
+      ["Add ECT - TRN", "Teacher reference number", "Enter the teacher reference number (TRN)", 19],
+      ["Setup cohort - appropriate body", "Have you appointed an appropriate body?", "Select whether you’ve appointed an appropriate body or not", 13],
+      ["Add ECT - DOB", "Date of birth", "Enter a date of birth", 11],
+      ["Add ECT - DOB", "Date of birth", "Enter a valid of birth", 8],
+      ["Setup cohort - teaching school hub", "Teaching school hub", "Select an appropriate body", 8],
+      ["Add ECT - Email", "Email address", "Enter an email address in the correct format, like name@example.com", 6],
+      ["Add ECT - TRN", "Teacher reference number", "Teacher reference number must include at least 5 digits", 2],
+      ["Add ECT - Email", "Email address", "Enter an email address in the correct format, like name@example.com", 6],
+      ["Add mentor - DOB", "Date of birth", "Enter a date of birth", 2]
+    
+    ] %}
+    
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Common errors shown</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Page</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Field</th>
+          <th scope="col" class="govuk-table__header">Error</th>
+          <th scope="col" class="govuk-table__header  govuk-table__header--numeric">Count</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        {% for row in data %}
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><a href="/admin/performance/errors/page" class="govuk-link">{{ row[0] }}</a></th>
+          <td class="govuk-table__cell">{{ row[1] }}</td>
+          <td class="govuk-table__cell">{{ row[2] }}</td>
+          <td class="govuk-table__cell  govuk-table__cell--numeric">{{ row[3] }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/admin/performance/errors/page.html
+++ b/app/views/admin/performance/errors/page.html
@@ -1,0 +1,65 @@
+{% extends "layouts/admin.html" %}
+
+{% set pageName="Add ECT - Email" %}
+{% set currentSection="performance" %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Performance",
+        href: "/admin/performance"
+      },
+      {
+        text: "Validation errors",
+        href: "/admin/performance/errors"
+      }
+    ]
+    
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    
+    <h1 class="govuk-heading-l"> {{ pageName }}</h1>
+    
+    <h2 class="govuk-heading-m">Validation errors</h2>
+    
+    {% set errors = [
+      ["Enter an email address in the correct format, like name@example.com", "anna .smith@schoolname.sch.uk", "Alisa Green"],
+      ["Enter an email address in the correct format, like name@example.com", "janebrownschoolname.sch.uk", "Anna Smith"],
+      ["Enter an email address", "", "Bryan Weaver"],
+      ["Enter an email address in the correct format, like name@example.com", "robert.smith@schoolname@sch.uk", "Rob Baker"]
+    ] %}
+    
+    {% for error in errors %}
+      <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+          <h2 class="govuk-summary-card__title govuk-!-font-weight-regular">Validation error <a href="#" class="govuk-link">#8463{{ loop.index }}</a> – 13 November 2022 at 11:{{ 58 - (loop.index * 9) }} am by user <a href="#">{{ error[2] }}</a></h2>
+        </div>
+        <div class="govuk-summary-card__content">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Email address
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <div class="govuk-error-message govuk-!-font-weight-regular">{{ error[0] }}</div>
+                <code class="app-user-input-example">{{ error[1] }}</code>
+                <br>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    {% endfor %}
+    
+    <p>[etc]</p>
+    
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/layouts/admin.html
+++ b/app/views/layouts/admin.html
@@ -1,0 +1,52 @@
+{#
+For guidance on how to use layouts see:
+https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
+#}
+
+{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
+
+{% set containerClasses = "app-width-container--wide" %}
+
+{% block header %}
+  {{ govukHeader({
+    serviceName: serviceName,
+    classes: "app-header--full-width-blue-border app-header--wide",
+    navigation: [
+      {
+        href: "#",
+        text: "Sign out"
+      }
+    ]
+  }) }}
+
+  {{ xGovukPrimaryNavigation({
+    classes: "app-primary-navigation--no-horizontal-padding app-primary-navigation--wide app-primary-navigation--shorter app-primary-navigation--less-padding",
+    visuallyHiddenTitle: "Navigation",
+    items: [{
+      text: "Overview",
+      href: "/admin"
+    }, {
+      text: "Schools",
+      href: "/admin/schools"
+    }, {
+      text: "ECTs",
+      href: "/admin/ects"
+    }, {
+      text: "Mentors",
+      href: "/admin/mentors"
+    }, {
+      text: "Providers",
+      href: "/admin/suppliers"
+    }, {
+      text: "Appropriate bodies",
+      href: "/admin/appropriate-bodies"
+    }, {
+      text: "Performance",
+      href: "/admin/performance",
+      current: (currentSection == "performance")
+    }, {
+      text: "Admin users",
+      href: "/admin/admin-users"
+    }]
+  }) }}
+{% endblock %}


### PR DESCRIPTION
This is a quick design for how we can summarise and show validation errors seen by users on each page.

The design is based on examples used in other DfE services.

## Validation errors summary page

![validation-errors](https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/2cde30ec-3735-4e22-a005-02d09dbb72d7)

## Validation errors detail page

![validation errors - page](https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/1e55ff58-a27d-4314-822b-656a7ce9c0a8)

