### PR TITLE
Add page in admin for stats on contact support form

### DIFF
--- a/app/views/admin/performance/_secondary-nav.html
+++ b/app/views/admin/performance/_secondary-nav.html
@@ -9,5 +9,8 @@
     <li class="app-subnav__list-item  {{ "app-subnav__list-item--selected" if currentSubSection == "emails" }}">
       <a class="govuk-link app-subnav__link govuk-link--no-visited-state" href="/admin/performance/emails">Email schedule</a>
     </li>
+    <li class="app-subnav__list-item  {{ "app-subnav__list-item--selected" if currentSubSection == "support-contacts" }}">
+      <a class="govuk-link app-subnav__link govuk-link--no-visited-state" href="/admin/performance/support-contacts">Support form stats</a>
+    </li>
   </ul>
 </nav>

--- a/app/views/admin/performance/support-contacts.html
+++ b/app/views/admin/performance/support-contacts.html
@@ -1,0 +1,55 @@
+{% extends "layouts/admin.html" %}
+
+{% set pageName="Support form stats" %}
+{% set currentSection="performance" %}
+{% set currentSubSection="support-contacts" %}
+
+{% block beforeContent %}
+  {% include "admin/performance/_secondary-nav" %}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+
+    <h1 class="govuk-heading-l">{{ pageName }}</h1>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">What were they trying to do?</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Support forms sent</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Number of users</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Change lead provider for an ECT</th>
+          <td class="govuk-table__cell  govuk-table__cell--numeric">14</td>
+          <td class="govuk-table__cell  govuk-table__cell--numeric">10</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Change lead provider for a mentor</th>
+          <td class="govuk-table__cell  govuk-table__cell--numeric">13</td>
+          <td class="govuk-table__cell  govuk-table__cell--numeric">6</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Change date of birth for an ECT</th>
+          <td class="govuk-table__cell  govuk-table__cell--numeric">2</td>
+          <td class="govuk-table__cell  govuk-table__cell--numeric">2</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Change TRN for an ECT</th>
+          <td class="govuk-table__cell  govuk-table__cell--numeric">1</td>
+          <td class="govuk-table__cell  govuk-table__cell--numeric">1</td>
+        </tr>
+      </tbody>
+    </table>
+
+
+
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
We're launching a new feature where users can contact support directly through the service.

This adds a page to the admin UI which would allow us to track usages of the form, broken down by the type of action the users were trying to do.

## Screenshot

<img width="1383" alt="Screenshot 2023-11-28 at 11 36 15" src="https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/30665/d0c3cc40-e979-4369-bc6a-210454b82626">
