### PR TITLE
Fix the Add ECT flow

### DIFF
--- a/app/routes/early-career-teachers.js
+++ b/app/routes/early-career-teachers.js
@@ -2,6 +2,8 @@
 
 module.exports = router => {
 
+  let randomId = require('../random-id.js')
+
   router.get('/early-career-teachers', (req, res) => {
 
     let mentors = JSON.parse(JSON.stringify(req.session.data.mentors))
@@ -272,6 +274,22 @@ module.exports = router => {
     })
   })
 
+  router.post('/early-career-teachers/add/answer-email', (req, res) => {
+
+    // In the live service, the system will use the DOB, email and TRN
+    // to check whether the ECT has already started their training at
+    // another school, and if so, asks the new school when they are moving.
+    //
+    // In this prototype, you can can test this flow by setting the a date
+    // of birth where the month is January.
+    const dobMonth = req.session.data.dob.month
+    if (dobMonth === "1") {
+      res.redirect('/early-career-teachers/add/moving-date')
+    } else {
+      res.redirect('/early-career-teachers/add/check')
+    }
+
+  })
 
 
   router.post('/early-career-teachers/add/answer-new-programme', (req, res) => {
@@ -283,6 +301,37 @@ module.exports = router => {
     } else {
       res.redirect('/early-career-teachers/add/check')
     }
+
+  })
+
+
+  router.post('/early-career-teachers/add/confirm', (req, res) => {
+
+    let data = req.session.data
+
+    let dob = new Date(data.dob.year, data.dob.month, data.dob.day).toISOString().slice(0,10)
+
+    let ect = {
+      id: randomId.randomId(),
+      name: data.name,
+      trn: data.trn,
+      dateOfBirth: dob,
+      emailAddress: data.email,
+      mentors: []
+    }
+
+    req.session.data.teachers.push(ect)
+
+    // Reset the "Add ECT" flow
+    delete data.name
+    delete data.trn
+    delete data.dob
+    delete data.email
+    delete data.startingOn
+    delete data.continueWithProgramme
+    delete data.newProvider
+
+    res.redirect(`/early-career-teachers/${ect.id}?justAdded=true`)
 
   })
 

--- a/app/views/early-career-teachers/add/check.html
+++ b/app/views/early-career-teachers/add/check.html
@@ -90,87 +90,90 @@
     }) }}
 
 
-    <h2 class="govuk-heading-m">Training details</h2>
+    {% if data.continueWithProgramme %}
+      <h2 class="govuk-heading-m">Training details</h2>
 
-    {% set trainingProviderText %}
-      {% if data.continueWithProgramme == "yes" %}
-        Best Practice Network
-      {% elif data.newProvider === "ambition-with-selby" %}
-        Ambition Institute
-      {% elif data.newProvider === "niot-with-northamptonshire" %}
-        National Institute of Teaching
-      {% endif %}
-    {% endset %}
+      {% set trainingProviderText %}
+        {% if data.continueWithProgramme == "yes" %}
+          Best Practice Network
+        {% elif data.newProvider === "ambition-with-selby" %}
+          Ambition Institute
+        {% elif data.newProvider === "niot-with-northamptonshire" %}
+          National Institute of Teaching
+        {% endif %}
+      {% endset %}
 
-    {% set deliveryPartnerText %}
-      {% if data.continueWithProgramme == "yes" %}
-        West LLC
-      {% elif data.newProvider === "ambition-with-selby" %}
-        Selby Teaching School Hub
-      {% elif data.newProvider === "niot-with-northamptonshire" %}
-        Northamptonshire Teaching School Hub
-      {% endif %}
-    {% endset %}
+      {% set deliveryPartnerText %}
+        {% if data.continueWithProgramme == "yes" %}
+          West LLC
+        {% elif data.newProvider === "ambition-with-selby" %}
+          Selby Teaching School Hub
+        {% elif data.newProvider === "niot-with-northamptonshire" %}
+          Northamptonshire Teaching School Hub
+        {% endif %}
+      {% endset %}
 
-    {{ govukSummaryList({
-      classes: 'govuk-!-margin-bottom-9',
-      rows: [
-        {
-          key: {
-            text: "Date they are joining your school"
+      {{ govukSummaryList({
+        classes: 'govuk-!-margin-bottom-9',
+        rows: [
+          {
+            key: {
+              text: "Date they are joining your school"
+            },
+            value: {
+              text: (data.startingOn | isoDateFromDateInput | govukDate )
+            },
+            actions: {
+              items: [
+                {
+                  href:  "/early-career-teachers/add/moving-date",
+                  text: "Change",
+                  visuallyHiddenText: " date they are joining your school"
+                }
+              ]
+            }
           },
-          value: {
-            text: (data.startingOn | isoDateFromDateInput | govukDate )
+          {
+            key: {
+              text: "Lead provider"
+            },
+            value: {
+              text: trainingProviderText
+            },
+            actions: {
+              items: [
+                {
+                  href:  "/early-career-teachers/add/continuing-programme",
+                  text: "Change",
+                  visuallyHiddenText: " training provider"
+                }
+              ]
+            }
           },
-          actions: {
-            items: [
-              {
-                href:  "/early-career-teachers/add/moving-date",
-                text: "Change",
-                visuallyHiddenText: " date they are joining your school"
-              }
-            ]
+          {
+            key: {
+              text: "Delivery partner"
+            },
+            value: {
+              text: deliveryPartnerText
+            },
+            actions: {
+              items: [
+                {
+                  href:  "/early-career-teachers/add/continuing-programme",
+                  text: "Change",
+                  visuallyHiddenText: " delivery partner"
+                }
+              ]
+            }
           }
-        },
-        {
-          key: {
-            text: "Lead provider"
-          },
-          value: {
-            text: trainingProviderText
-          },
-          actions: {
-            items: [
-              {
-                href:  "/early-career-teachers/add/continuing-programme",
-                text: "Change",
-                visuallyHiddenText: " training provider"
-              }
-            ]
-          }
-        },
-        {
-          key: {
-            text: "Delivery partner"
-          },
-          value: {
-            text: deliveryPartnerText
-          },
-          actions: {
-            items: [
-              {
-                href:  "/early-career-teachers/add/continuing-programme",
-                text: "Change",
-                visuallyHiddenText: " delivery partner"
-              }
-            ]
-          }
-        }
-      ]
-    }) }}
+        ]
+      }) }}
+    {% endif %}
 
-
-    {{ govukButton({ text: "Confirm and continue", href: "#"}) }}
+    <form action="/early-career-teachers/add/confirm" method="post">
+      {{ govukButton({ text: "Confirm and continue" }) }}
+    </form>
 
   </div>
 </div>

--- a/app/views/early-career-teachers/add/email.html
+++ b/app/views/early-career-teachers/add/email.html
@@ -13,7 +13,7 @@
 
     <span class="govuk-caption-l">Plymouth Primary School</span>
 
-    <form action="/early-career-teachers/add/moving-date" method="post">
+    <form action="/early-career-teachers/add/answer-email" method="post">
       {{ govukInput({
         name: "email",
         id: "email",


### PR DESCRIPTION
This fixes the Add ECT flow (after splitting it from Add mentor), so that the resulting ECT gets added to the interface.

If you set the month of birth to January, you'll see the 'transfer-in' flow, otherwise you'll see the regular flow for new ECTs.