### PR TITLE
UR schools filter screen

### DIFF
--- a/app/views/_includes/search-form.njk
+++ b/app/views/_includes/search-form.njk
@@ -20,6 +20,6 @@
   </form>
 
   {% if data.search.schoolName %}
-    <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><a class="govuk-link--no-visited-state" href="/schools/clear-search">Clear search</a></p>
+    {# <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><a class="govuk-link--no-visited-state" href="/schools/clear-search">Clear search</a></p> #}
   {% endif %}
 </div>

--- a/app/views/admin/alt-table-style.html
+++ b/app/views/admin/alt-table-style.html
@@ -1,0 +1,40 @@
+<div class="school-list">
+    {% for school in schools %}
+      <div class="school-list__item">
+        <h2 class="govuk-heading-s">
+          <a href="/admin/schools/{{ school.id }}">
+            {{ school.name }}
+          </a>
+        </h2>
+
+        
+        {{ govukTag({
+          text: school.schoolType,
+          classes: "govuk-tag-programme",
+          classes: school.schoolType | statusColour 
+        }) }}
+
+        {{ govukSummaryList({
+          classes: "govuk-summary-list--no-border govuk-summary-list-schools",
+          rows: [
+            {
+              key: {
+                text: "URN"
+              },
+              value: {
+                text: school.id
+              }
+            },
+            {
+              key: {
+                text: "Induction tutor email"
+              },
+              value: {
+                text: school.inductionTutorEmail
+              }
+            }
+          ]
+        }) }}
+      </div>
+    {% endfor %}
+  </div>

--- a/app/views/admin/ects.html
+++ b/app/views/admin/ects.html
@@ -11,11 +11,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      <h1 class="govuk-heading-l">{{ pageName }}</h1>
+      <h1 class="govuk-heading-xl">{{ pageName }}</h1>
       
-      <div class="govuk-body govuk-!-padding-4" style="background-color: #f3f2f1; height:100px; text-align: center;">
-        [Search and filter form]
-      </div>
+      {% include "_includes/search-form.njk" %}
       
       {% set names = ["Jaxon Brewer", "Marvin Lawrence", "Dayton Shelton", "Jamarion Acosta", "Addison Mercer", "Rosa Davenport", "Konner Anderson", "Hannah Hunter", "Brooks Castro", "Rodolfo Harmon", "Wyatt Larson", "Maren Christian"] %}
       

--- a/app/views/admin/overview.html
+++ b/app/views/admin/overview.html
@@ -5,7 +5,7 @@
 {% set currentSubSection="overview" %}
 
 {% block beforeContent %}
-  {% include "admin/performance/_secondary-nav" %}
+  
 {% endblock %}
 
 {% block content %}
@@ -16,6 +16,8 @@
 
 
     <h1 class="govuk-heading-l">Overview</h1>
+
+    {% include "admin/performance/_secondary-nav" %}
     
     <table class="govuk-table govuk-!-margin-bottom-9">
       <caption class="govuk-table__caption govuk-table__caption--m">Schools registered for 2023 to 2024</caption>

--- a/app/views/admin/overview.html
+++ b/app/views/admin/overview.html
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
 
 
-    <h1 class="govuk-heading-l">Overview</h1>
+    <h1 class="govuk-heading-xl">Overview</h1>
 
     {% include "admin/performance/_secondary-nav" %}
     

--- a/app/views/admin/performance/_secondary-nav.html
+++ b/app/views/admin/performance/_secondary-nav.html
@@ -1,10 +1,10 @@
 {{ xGovukSecondaryNavigation({
-  classes: "govuk-!-margin-top-9 govuk-!-padding-bottom-0",
+  classes: "govuk-!-margin-top-0 govuk-!-padding-bottom-6",
   visuallyHiddenTitle: "Secondary menu",
   items: [
     {
       text: "Overview",
-      href: "/admin/",
+      href: "/admin/overview",
       current: (currentSubSection == "overview")
     },
     {

--- a/app/views/admin/performance/_secondary-nav.html
+++ b/app/views/admin/performance/_secondary-nav.html
@@ -10,7 +10,7 @@
     {
       text: "Validation errors",
       href: "/admin/performance/errors",
-      selected: (currentSubSection == "errors")
+      current: (currentSubSection == "errors")
     },
     {
       text: "Email schedule",

--- a/app/views/admin/performance/emails.html
+++ b/app/views/admin/performance/emails.html
@@ -4,17 +4,16 @@
 {% set currentSection="performance" %}
 {% set currentSubSection="emails" %}
 
-{% block beforeContent %}
-  {% include "admin/performance/_secondary-nav" %}
-{% endblock %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
 
-    <h1 class="govuk-heading-l"> {{ pageName }}</h1>
+    <h1 class="govuk-heading-xl"> {{ pageName }}</h1>
 
+    {% include "admin/performance/_secondary-nav" %} 
+    
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--m">Upcoming emails</caption>
       <thead class="govuk-table__head">

--- a/app/views/admin/performance/errors.html
+++ b/app/views/admin/performance/errors.html
@@ -4,16 +4,15 @@
 {% set currentSection="performance" %}
 {% set currentSubSection="errors" %}
 
-{% block beforeContent %}
-  {% include "admin/performance/_secondary-nav" %}
-{% endblock %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     
-    <h1 class="govuk-heading-l"> {{ pageName }}</h1>
+    <h1 class="govuk-heading-xl"> {{ pageName }}</h1>
+
+    {% include "admin/performance/_secondary-nav" %}
     
     {% set data = [
       ["Add mentor - TRN", "Teacher reference number", "Enter the teacher reference number (TRN)", 52],

--- a/app/views/admin/performance/support-contacts.html
+++ b/app/views/admin/performance/support-contacts.html
@@ -4,16 +4,15 @@
 {% set currentSection="performance" %}
 {% set currentSubSection="support-contacts" %}
 
-{% block beforeContent %}
-  {% include "admin/performance/_secondary-nav" %}
-{% endblock %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
 
-    <h1 class="govuk-heading-l">{{ pageName }}</h1>
+    <h1 class="govuk-heading-xl">{{ pageName }}</h1>
+
+    {% include "admin/performance/_secondary-nav" %}
 
     <table class="govuk-table">
       <thead class="govuk-table__head">

--- a/app/views/admin/schools.html
+++ b/app/views/admin/schools.html
@@ -2,6 +2,7 @@
 
 {% set pageName="Schools" %}
 {% set currentSection="schools" %}
+{% set currentSubSection="filters" %}
 
 
 {% set filters = req.session.data.filters %}
@@ -18,12 +19,13 @@
     <h1 class="govuk-heading-xl">{{ pageName }} ({{pagination.totalCount}})</h1>
   </div>
 
+
   <div class="moj-page-header-actions__actions">
 
     <div class="moj-button-menu">
       <div class="moj-button-menu__wrapper">
 
-        <a href="/admin/extract.html" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary moj-page-header-actions__action" data-module="govuk-button">Download results</a>
+        <a href="/admin/extract.html" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--primary moj-page-header-actions__action" data-module="govuk-button">Download results</a>
 
       </div>
     </div>
@@ -32,6 +34,8 @@
 
 </div>
 
+{% include "admin/schools/_secondary-nav" %}
+
   {{data.schools | log}}
 
   <div class="app-filter-layout">
@@ -39,8 +43,6 @@
       {% include "_includes/filter-panel.njk" %}
     </div>
     <div class="app-filter-layout__content">
-
-      {% include "_includes/search-form.njk" %}
 
       <div class="app-action-bar">
         <div class="app-action-bar__filter"></div>

--- a/app/views/admin/schools/_secondary-nav.html
+++ b/app/views/admin/schools/_secondary-nav.html
@@ -1,25 +1,19 @@
 {{ xGovukSecondaryNavigation({
-  classes: "govuk-!-margin-top-9 govuk-!-padding-bottom-0",
+  classes: "govuk-!-margin-top-0 govuk-!-padding-bottom-6",
   visuallyHiddenTitle: "Secondary menu",
   items: [
     {
-      text: "Details",
-      href: "/admin/schools/" + schools.id,
-      current: (currentSubSection == "details")
+      text: "Schools",
+      href: "/admin/schoolslist",
+      current: (currentSubSection == "schoolslist")
     },
     {
-      text: "ECTs",
-      href: "/admin/schools/" + schools.id + "/ects",
-      current: (currentSubSection == "ects")
-    },
-    {
-      text: "Mentors",
-      href: "/admin/schools/" + schools.id + "/mentors",
-      current: (currentSubSection == "mentors")
-    },
-    {
-      text: "Cohorts",
-      href: "#"
+      text: "Filters",
+      href: "/admin/schools",
+      current: (currentSubSection == "filters")
     }
   ]
 }) }}
+
+
+

--- a/app/views/admin/schools/ects.html
+++ b/app/views/admin/schools/ects.html
@@ -6,7 +6,34 @@
 
 {% block beforeContent %}
   <h1 class="govuk-heading-l govuk-!-margin-top-7 govuk-!-margin-bottom-4">{{ pageName }}</h1>
-  {% include "admin/schools/_secondary-nav" %}
+  {# {% include "admin/schools/_secondary-nav" %} #}
+
+  {{ xGovukSecondaryNavigation({
+    classes: "govuk-!-margin-top-9 govuk-!-padding-bottom-0",
+    visuallyHiddenTitle: "Secondary menu",
+    items: [
+      {
+        text: "Details",
+        href: "/admin/schools/" + school.id,
+        current: (currentSubSection == "details")
+      },
+      {
+        text: "ECTs",
+        href: "/admin/schools/" + school.id + "/ects",
+        current: (currentSubSection == "ects")
+      },
+      {
+        text: "Mentors",
+        href: "/admin/schools/" + school.id + "/mentors",
+        current: (currentSubSection == "mentors")
+      },
+      {
+        text: "Cohorts",
+        href: "#"
+      }
+    ]
+  }) }}
+
 {% endblock %}
 
 {% block content %}

--- a/app/views/admin/schools/mentors.html
+++ b/app/views/admin/schools/mentors.html
@@ -6,7 +6,34 @@
 
 {% block beforeContent %}
   <h1 class="govuk-heading-l govuk-!-margin-top-7 govuk-!-margin-bottom-4">{{ school.name }}</h1>
-  {% include "admin/schools/_secondary-nav" %}
+  {# {% include "admin/schools/_secondary-nav" %} #}
+
+  {{ xGovukSecondaryNavigation({
+    classes: "govuk-!-margin-top-9 govuk-!-padding-bottom-0",
+    visuallyHiddenTitle: "Secondary menu",
+    items: [
+      {
+        text: "Details",
+        href: "/admin/schools/" + school.id,
+        current: (currentSubSection == "details")
+      },
+      {
+        text: "ECTs",
+        href: "/admin/schools/" + school.id + "/ects",
+        current: (currentSubSection == "ects")
+      },
+      {
+        text: "Mentors",
+        href: "/admin/schools/" + school.id + "/mentors",
+        current: (currentSubSection == "mentors")
+      },
+      {
+        text: "Cohorts",
+        href: "#"
+      }
+    ]
+  }) }}
+  
 {% endblock %}
 
 {% block content %}

--- a/app/views/admin/schools/show.html
+++ b/app/views/admin/schools/show.html
@@ -8,7 +8,21 @@
 
 {% block beforeContent %}
   <h1 class="govuk-heading-l govuk-!-margin-top-7 govuk-!-margin-bottom-4">{{ pageName }}</h1>
-  {% include "admin/schools/_secondary-nav" %}
+  {# {% include "admin/schools/_secondary-nav" %} #}
+  {{ xGovukSecondaryNavigation({
+    visuallyHiddenTitle: "Secondary menu",
+    items: [{
+      text: "Details",
+      href: "#",
+      current: true
+    }, {
+      text: "Participants",
+      href: "#"
+    }, {
+      text: "Cohorts",
+      href: "#"
+    }]
+  }) }}
 {% endblock %}
 
 {% block content %}
@@ -21,7 +35,7 @@
     {{ data.schools | log }}
 
       {{ govukSummaryList({
-        rows: [
+        rows: [                     
           {
             key: {
               text: "URN"

--- a/app/views/admin/schools/show.html
+++ b/app/views/admin/schools/show.html
@@ -3,26 +3,40 @@
 {% set pageName = school.name %}
 
 {% set currentSection="schools" %}
-{% set currentSubSection="schoolslist" %}
+{% set currentSubSection="details" %}
 
 
 {% block beforeContent %}
   <h1 class="govuk-heading-l govuk-!-margin-top-7 govuk-!-margin-bottom-4">{{ pageName }}</h1>
   {# {% include "admin/schools/_secondary-nav" %} #}
+
   {{ xGovukSecondaryNavigation({
+    classes: "govuk-!-margin-top-9 govuk-!-padding-bottom-0",
     visuallyHiddenTitle: "Secondary menu",
-    items: [{
-      text: "Details",
-      href: "#",
-      current: true
-    }, {
-      text: "Participants",
-      href: "#"
-    }, {
-      text: "Cohorts",
-      href: "#"
-    }]
+    items: [
+      {
+        text: "Details",
+        href: "/admin/schools/" + school.id,
+        current: (currentSubSection == "details")
+      },
+      {
+        text: "ECTs",
+        href: "/admin/schools/" + school.id + "/ects",
+        current: (currentSubSection == "ects")
+      },
+      {
+        text: "Mentors",
+        href: "/admin/schools/" + school.id + "/mentors",
+        current: (currentSubSection == "mentors")
+      },
+      {
+        text: "Cohorts",
+        href: "#"
+      }
+    ]
   }) }}
+
+
 {% endblock %}
 
 {% block content %}

--- a/app/views/admin/schools/show.html
+++ b/app/views/admin/schools/show.html
@@ -3,7 +3,7 @@
 {% set pageName = school.name %}
 
 {% set currentSection="schools" %}
-{% set currentSubSection="details" %}
+{% set currentSubSection="schoolslist" %}
 
 
 {% block beforeContent %}

--- a/app/views/admin/schoolslist.html
+++ b/app/views/admin/schoolslist.html
@@ -33,7 +33,7 @@
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><a href="/admin/schools/{{ school.id }}" class="govuk-link">{{ school.name }}</a></th>
               <td class="govuk-table__cell">{{ 736524 - (loop.index0 * 33438) }}</td>
-              <td class="govuk-table__cell">headteacher.name@school-name.sch.uk</td>
+              <td class="govuk-table__cell">{{ school.inductionTutorEmail }}</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/app/views/admin/schoolslist.html
+++ b/app/views/admin/schoolslist.html
@@ -1,0 +1,45 @@
+{% extends "layouts/admin.html" %}
+
+{% set pageName="Schools" %}
+{% set currentSection="schools" %}
+{% set currentSubSection="schoolslist" %}
+
+
+
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <h1 class="govuk-heading-xl">{{ pageName }}</h1>
+
+      
+        {% include "admin/schools/_secondary-nav" %}
+      
+
+        {% include "_includes/search-form.njk" %}
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">School</th>
+            <th scope="col" class="govuk-table__header">URN</th>
+            <th scope="col" class="govuk-table__header">Induction tutor</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          {% for school in data.schools %}
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><a href="/admin/schools/{{ school.id }}" class="govuk-link">{{ school.name }}</a></th>
+              <td class="govuk-table__cell">{{ 736524 - (loop.index0 * 33438) }}</td>
+              <td class="govuk-table__cell">headteacher.name@school-name.sch.uk</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/early-career-teachers/index.html
+++ b/app/views/early-career-teachers/index.html
@@ -54,6 +54,8 @@
     </form>
   </div>
 
+  <a href="/admin/overview" class="govuk-link" style="color: rgb(228, 228, 228); font-size: 20px;">Switch to admin view</a>
+  
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/layouts/admin.html
+++ b/app/views/layouts/admin.html
@@ -24,11 +24,11 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
     visuallyHiddenTitle: "Navigation",
     items: [{
       text: "Performance",
-      href: "/admin",
+      href: "/admin/overview",
       current: (currentSection == "performance")
     }, {
       text: "Schools",
-      href: "/admin/schools",
+      href: "/admin/schoolslist",
       current: (currentSection == "schools")
     }, {
       text: "ECTs",


### PR DESCRIPTION
- Existing Schools screen has new sub nav added with 'Schools' and 'Filters' categories.
- ![Screenshot 2024-02-13 at 13 42 26](https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/78021112/eff8dd70-cc0f-42ff-8c8b-5f2d55ce944a)

- On selecting the Filters category you arrive at the filters page, now without a search bar 
- The Filters page has the same sub nav with 'Schools' and 'Filters' categories.
![Screenshot 2024-02-13 at 13 42 39](https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/assets/78021112/10051c02-8cd4-4f5b-9b9a-14f50a816422)


Keeping the filters pattern the same as we can repurpose the Moj pattern/components from here:
https://design-patterns.service.justice.gov.uk/components/filter/
